### PR TITLE
FW-735: Pipeline failing - changes to Enum class in Python 3.12.10

### DIFF
--- a/src/time_stream/bitwise.py
+++ b/src/time_stream/bitwise.py
@@ -11,6 +11,7 @@ class BitwiseMeta(EnumType):
 
 class BitwiseFlag(int, Flag, metaclass=BitwiseMeta):
     """A flag enumeration that allows efficient flagging using bitwise operations."""
+
     def __init_subclass__(cls, **kwargs):
         """Validate enum member values on class definition."""
         super().__init_subclass__(**kwargs)


### PR DESCRIPTION
It looks like 3.12.10 included some updates to the Enum class that is causing a new TypeError when setting up a new BitwiseFlag class.

See changelog: https://docs.python.org/release/3.12.10/whatsnew/changelog.html#python-3-12-10

Specifically:  **gh-108682**: Enum: require names=() or type=... to create an empty enum using the functional syntax.
https://github.com/python/cpython/issues/108682

Looks like stricter validation introduced in the enum module. Specifically, when instantiating an enumeration, Python now raises a TypeError if the class has no members defined. This change was implemented to prevent the creation of empty Flag enumerations without explicitly specifying that intention.

In our implementation, overriding the `__new__` class method, was interfering with how members are registered during enum class creation and leading to the above type error.

Looks like fix is to just move validation done in `__new__` to a new place (`__init_subclass__`).

**Note**
This error was introduced in the Github pipeline, but was not showing up when running locally.  Github was using the latest 3.12.10 Python release, whereas locally, was still using 3.12.3 (the latest version available in the apt deadsnakes ppa). 

Had to install 3.12.10 locally by building the binaries manually.  