### PR TITLE
FW-690 - Update init for pyright discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Whilst time-stream is under active development, to use time-stream within your p
 
     **Using pip directly**
     ```commandline
-    pip install -e "time-stream @ git+https://github.com/NERC-CEH/time-stream.git"
+    pip install "time-stream @ git+https://github.com/NERC-CEH/time-stream.git"
     ```
     
     **In your project's pyproject.toml**

--- a/src/time_stream/__init__.py
+++ b/src/time_stream/__init__.py
@@ -1,4 +1,12 @@
+from typing import TYPE_CHECKING, Any
+
 import autosemver
+
+if TYPE_CHECKING:
+    # These imports are only for static type checkers (e.g., Pyright, IDEs).
+    # At runtime, they are not executed, so the modules won't be imported unless needed.
+    from time_stream.base import TimeSeries
+    from time_stream.period import Period
 
 try:
     __version__ = autosemver.packaging.get_current_version(project_name="time_stream")
@@ -6,10 +14,19 @@ except Exception:
     __version__ = "0.0.0"
 
 
+# Declare the public API of the package. This tells `from time_stream import *` what to include.
 __all__ = ["TimeSeries", "Period"]  # noqa
 
 
-def __getattr__(name: str) -> None:
+def __getattr__(name: str) -> Any:
+    # NOTE: We use __getattr__ for lazy imports instead of top-level imports because setuptools may evaluate
+    #   this module during build (e.g., to use the value of time_stream.__version__), before submodules like
+    #   `time_stream.base` or `time_stream.period` exist. This avoids import-time errors when building from source
+    #   using pyproject.toml and ensures compatibility with dynamic versioning tools like autosemver.
+    #
+    #   This 'lazy loading' also has additional benefits in that it can help with performance by avoiding unnecessary
+    #   dependencies being loaded at startup and also gives us control over what to expose from the package.
+
     if name == "TimeSeries":
         from time_stream.base import TimeSeries
 


### PR DESCRIPTION
Pyright static type checker was reporting false errors when working with the TimeSeries and Period classes imported from the time-stream package. 

Updated the `__init__.py` of time-stream to add TYPE_CHECKING imports to fix this.  Some comments in there to explain what's going on. 

## Reproducing the errors

### Using existing time-stream repo:
Set up a minimal new project, with a pip env with the following installs:

`pip install "time-stream @ git+https://github.com/NERC-CEH/time-stream.git"`
`pip install pyright`

Now create a python file called "pyright_check.py" with the content:

```
from time_stream import TimeSeries, Period

import polars as pl

ts: TimeSeries = TimeSeries(pl.DataFrame(), "time")
p: Period = Period.of_days(1)
```

And run:

`pyright pyright_check.py`

This should give errors such as:

```
 /home/ricsmi/source/repos/fdri/pyright_test/pyright_check.py:5:5 - error: Expected class but received "None" (reportGeneralTypeIssues)
  /home/ricsmi/source/repos/fdri/pyright_test/pyright_check.py:5:18 - error: Object of type "None" cannot be called (reportOptionalCall)
  /home/ricsmi/source/repos/fdri/pyright_test/pyright_check.py:6:4 - error: Expected class but received "None" (reportGeneralTypeIssues)
  /home/ricsmi/source/repos/fdri/pyright_test/pyright_check.py:6:20 - error: Cannot access attribute "of_days" for class "None"
```

### Updated time-stream:
Now if you uninstall the github repo version of time-stream:

`pip uninstall time-stream`

And install your local version (assuming you've cloned this branch locally):

`pip install -e ~/path/to/time-stream/`

And re-run:

`pyright pyright_check.py`

There should be no errors
