### PR TITLE
FPM-295 Strategies for dealing with duplicate rows

### DIFF
--- a/docs/source/user_guide/timeseries_basics.rst
+++ b/docs/source/user_guide/timeseries_basics.rst
@@ -151,6 +151,108 @@ The periodicity defines how frequently data points should appear:
    import examples_timeseries_basics
    ts = examples_timeseries_basics.periodicity_check_fail()
 
+Duplicate Detection
+~~~~~~~~~~~~~~~~~~~
+
+The ``TimeSeries`` automatically checks for rows with duplicates in the specified time column. You have control over
+what the model should do when it detects rows with duplicate time values.  Consider this DataFrame with duplicate
+time values:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_27]
+   :end-before: [end_block_27]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.create_df_with_duplicate_rows()
+
+The following strategies are available to use with the ``on_duplicate`` argument:
+
+1. Error Strategy (Default): ``on_duplicate="error"``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Raises an error when duplicate rows are found. This is the default behavior to ensure data integrity.
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_28]
+   :end-before: [end_block_28]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.aggregation_duplicate_row_example_error()
+
+2. Keep First Strategy: ``on_duplicate="keep_first"``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+For a given group of rows with the same time value, keeps only the first row and discards the others.
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_29]
+   :end-before: [end_block_29]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.aggregation_duplicate_row_example_keep_first()
+
+3. Keep Last Strategy: ``on_duplicate="keep_last"``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+For a given group of rows with the same time value, keeps only the last row and discards the others.
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_30]
+   :end-before: [end_block_30]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.aggregation_duplicate_row_example_keep_last()
+
+4. Drop Strategy: ``on_duplicate="drop"``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Removes all rows that have duplicate timestamps. This strategy is appropriate when you are unsure of the integrity of
+duplicate rows and only want unique, unambiguous data.
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_31]
+   :end-before: [end_block_31]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.aggregation_duplicate_row_example_drop()
+
+5. Merge Strategy: ``on_duplicate="merge"``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+For a given group of rows with the same time value, performs a merge of all rows. This combines values with a top-down
+approach that preserves the first non-null value for each column.
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_32]
+   :end-before: [end_block_32]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.aggregation_duplicate_row_example_merge()
 
 Accessing Data
 -------------

--- a/src/time_stream/enums.py
+++ b/src/time_stream/enums.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class DuplicateOption(Enum):
     """Enum representing the options for handling duplicate timestamp rows in a TimeSeries."""
+
     DROP = "drop"
     KEEP_FIRST = "keep_first"
     KEEP_LAST = "keep_last"

--- a/src/time_stream/enums.py
+++ b/src/time_stream/enums.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class DuplicateOption(Enum):
+    """Enum representing the options for handling duplicate timestamp rows in a TimeSeries."""
+    DROP = "drop"
+    KEEP_FIRST = "keep_first"
+    KEEP_LAST = "keep_last"
+    ERROR = "error"
+    MERGE = "merge"

--- a/src/time_stream/examples/examples_timeseries_basics.py
+++ b/src/time_stream/examples/examples_timeseries_basics.py
@@ -160,10 +160,10 @@ def resolution_check_fail():
 
 def periodicity_check_fail():
     # [start_block_9]
-    # This will raise a warning because we have two points in the same day
+    # This will raise a warning because we have two points within the same day
     timestamps = [
         datetime(2023, 1, 1, 0, 0, 0),
-        datetime(2023, 1, 1, 0, 0, 0),  # Same day as above
+        datetime(2023, 1, 1, 12, 0, 0),  # Same day as above
         datetime(2023, 1, 2, 0, 0, 0),
     ]
 
@@ -530,3 +530,113 @@ def aggregation_more_examples():
     annual_max_temp = ts.aggregate(Period.of_years(1), Max, "temperature")
     print(annual_max_temp)
     # [end_block_26]
+
+
+def create_df_with_duplicate_rows():
+    # [start_block_27]
+    # Create sample data
+    dates = [
+        datetime(2023, 1, 1),
+        datetime(2023, 1, 1),
+        datetime(2023, 2, 1),
+        datetime(2023, 3, 1),
+        datetime(2023, 4, 1),
+        datetime(2023, 5, 1),
+        datetime(2023, 6, 1),
+        datetime(2023, 6, 1),
+        datetime(2023, 6, 1),
+        datetime(2023, 7, 1),
+    ]
+    temperatures = [20, None, 19, 26, 24, 26, 28, 30, None, 29]
+    precipitation = [None, 0, 5, 10, 2, 0, None, 3, 4, 0]
+
+    df = pl.DataFrame({
+        "timestamp": dates,
+        "temperature": temperatures,
+        "precipitation": precipitation
+    })
+
+    print(df)
+    # [end_block_27]
+    return df
+
+
+def aggregation_duplicate_row_example_error():
+    with suppress_output():
+        df = create_df_with_duplicate_rows()
+
+    # [start_block_28]
+    # Raises an error if duplicate timestamps exist. This is the default if `on_duplicate` is not specified.
+    try:
+        ts = TimeSeries(
+            df=df,
+            time_name="timestamp",
+            on_duplicate="error"
+        )
+    except ValueError as w:
+        print(f"Warning: {w}")
+    # [end_block_28]
+
+
+def aggregation_duplicate_row_example_keep_first():
+    with suppress_output():
+        df = create_df_with_duplicate_rows()
+
+    # [start_block_29]
+    # Keeps the first row found in groups of duplicate rows
+    ts = TimeSeries(
+        df=df,
+        time_name="timestamp",
+        on_duplicate="keep_first"
+    )
+
+    print(ts)
+    # [end_block_29]
+
+
+def aggregation_duplicate_row_example_keep_last():
+    with suppress_output():
+        df = create_df_with_duplicate_rows()
+
+    # [start_block_30]
+    # Keeps the last row found in groups of duplicate rows
+    ts = TimeSeries(
+        df=df,
+        time_name="timestamp",
+        on_duplicate="keep_last"
+    )
+
+    print(ts)
+    # [end_block_30]
+
+
+def aggregation_duplicate_row_example_drop():
+    with suppress_output():
+        df = create_df_with_duplicate_rows()
+
+    # [start_block_31]
+    # Drops all duplicate rows
+    ts = TimeSeries(
+        df=df,
+        time_name="timestamp",
+        on_duplicate="drop"
+    )
+
+    print(ts)
+    # [end_block_31]
+
+
+def aggregation_duplicate_row_example_merge():
+    with suppress_output():
+        df = create_df_with_duplicate_rows()
+
+    # [start_block_32]
+    # Merges groups of duplicate rows
+    ts = TimeSeries(
+        df=df,
+        time_name="timestamp",
+        on_duplicate="merge"
+    )
+
+    print(ts)
+    # [end_block_32]

--- a/tests/time_stream/test_base.py
+++ b/tests/time_stream/test_base.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from polars.testing import assert_series_equal, assert_frame_equal
 
 from time_stream.base import TimeSeries
+from time_stream.enums import DuplicateOption
 from time_stream.period import Period
 from time_stream.columns import DataColumn, FlagColumn, PrimaryTimeColumn, SupplementaryColumn, TimeSeriesColumn
 
@@ -2548,7 +2549,6 @@ class TestHandleDuplicates(unittest.TestCase):
         with self.assertRaises(ValueError):
             ts._handle_duplicates()
 
-
     def test_keep_first(self):
         """ Test that the keep first strategy works as expected
         """
@@ -2662,3 +2662,13 @@ class TestHandleDuplicates(unittest.TestCase):
         })
 
         assert_frame_equal(ts.df, expected)
+
+    def test_enum_parameter(self):
+        """ Test that passing an enum rather than a string works as expected
+        """
+        with patch.object(TimeSeries, '_setup'):
+            # Omit the setup method so we have control over what we're testing
+            ts = TimeSeries(df=self.df, time_name="time", on_duplicate=DuplicateOption.ERROR)
+
+        with self.assertRaises(ValueError):
+            ts._handle_duplicates()

--- a/tests/time_stream/test_base.py
+++ b/tests/time_stream/test_base.py
@@ -2512,3 +2512,153 @@ class TestSubPeriodCheck(unittest.TestCase):
             TimeSeries(df=self.df, time_name="time",
                 resolution=Period.of_seconds(10),
                 periodicity=Period.of_seconds(1))
+
+
+class TestHandleDuplicates(unittest.TestCase):
+    def setUp(self):
+        # A dataframe with some duplicate times
+        self.df = pl.DataFrame({
+            "time": [
+                datetime(2024, 1, 1),
+                datetime(2024, 1, 1),
+                datetime(2024, 1, 2),
+                datetime(2024, 1, 3),
+                datetime(2024, 1, 4),
+                datetime(2024, 1, 5),
+                datetime(2024, 1, 6),
+                datetime(2024, 1, 7),
+                datetime(2024, 1, 8),
+                datetime(2024, 1, 8),
+                datetime(2024, 1, 8),
+                datetime(2024, 1, 9),
+                datetime(2024, 1, 10)
+            ],
+            "colA": [1, None, 2, 3, 4, 5, 6, 7, None, 8, 8, 9, 10],
+            "colB": [None, 1, 2, 3, 4, 5, 6, 7, 9, None, 9, 9, 10],
+            "colC": [None, 2, 2, 3, 4, 5, 6, 7, 8, 9, None, 9, 10],
+        })
+
+    def test_error(self):
+        """ Test that the keep first strategy works as expected
+        """
+        with patch.object(TimeSeries, '_setup'):
+            # Omit the setup method so we have control over what we're testing
+            ts = TimeSeries(df=self.df, time_name="time", on_duplicate="error")
+
+        with self.assertRaises(ValueError):
+            ts._handle_duplicates()
+
+
+    def test_keep_first(self):
+        """ Test that the keep first strategy works as expected
+        """
+        with patch.object(TimeSeries, '_setup'):
+            # Omit the setup method so we have control over what we're testing
+            ts = TimeSeries(df=self.df, time_name="time", on_duplicate="keep_first")
+
+        ts._handle_duplicates()
+
+        expected = pl.DataFrame({
+            "time": [
+                datetime(2024, 1, 1),
+                datetime(2024, 1, 2),
+                datetime(2024, 1, 3),
+                datetime(2024, 1, 4),
+                datetime(2024, 1, 5),
+                datetime(2024, 1, 6),
+                datetime(2024, 1, 7),
+                datetime(2024, 1, 8),
+                datetime(2024, 1, 9),
+                datetime(2024, 1, 10)
+            ],
+            "colA": [1, 2, 3, 4, 5, 6, 7, None, 9, 10],
+            "colB": [None, 2, 3, 4, 5, 6, 7, 9, 9, 10],
+            "colC": [None, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        })
+
+        assert_frame_equal(ts.df, expected)
+
+    def test_keep_last(self):
+        """ Test that the keep last strategy works as expected
+        """
+        with patch.object(TimeSeries, '_setup'):
+            # Omit the setup method so we have control over what we're testing
+            ts = TimeSeries(df=self.df, time_name="time", on_duplicate="keep_last")
+
+        ts._handle_duplicates()
+
+        expected = pl.DataFrame({
+            "time": [
+                datetime(2024, 1, 1),
+                datetime(2024, 1, 2),
+                datetime(2024, 1, 3),
+                datetime(2024, 1, 4),
+                datetime(2024, 1, 5),
+                datetime(2024, 1, 6),
+                datetime(2024, 1, 7),
+                datetime(2024, 1, 8),
+                datetime(2024, 1, 9),
+                datetime(2024, 1, 10)
+            ],
+            "colA": [None, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "colB": [1, 2, 3, 4, 5, 6, 7, 9, 9, 10],
+            "colC": [2, 2, 3, 4, 5, 6, 7, None, 9, 10],
+        })
+
+        assert_frame_equal(ts.df, expected)
+
+    def test_drop(self):
+        """ Test that the drop strategy works as expected
+        """
+        with patch.object(TimeSeries, '_setup'):
+            # Omit the setup method so we have control over what we're testing
+            ts = TimeSeries(df=self.df, time_name="time", on_duplicate="drop")
+
+        ts._handle_duplicates()
+
+        expected = pl.DataFrame({
+            "time": [
+                datetime(2024, 1, 2),
+                datetime(2024, 1, 3),
+                datetime(2024, 1, 4),
+                datetime(2024, 1, 5),
+                datetime(2024, 1, 6),
+                datetime(2024, 1, 7),
+                datetime(2024, 1, 9),
+                datetime(2024, 1, 10)
+            ],
+            "colA": [2, 3, 4, 5, 6, 7, 9, 10],
+            "colB": [2, 3, 4, 5, 6, 7, 9, 10],
+            "colC": [2, 3, 4, 5, 6, 7, 9, 10],
+        })
+
+        assert_frame_equal(ts.df, expected)
+
+    def test_merge(self):
+        """ Test that the merge strategy works as expected
+        """
+        with patch.object(TimeSeries, '_setup'):
+            # Omit the setup method so we have control over what we're testing
+            ts = TimeSeries(df=self.df, time_name="time", on_duplicate="merge")
+        ts._setup_columns()  # Need to run this setup for this test as we need the column details to be available
+        ts._handle_duplicates()
+
+        expected = pl.DataFrame({
+            "time": [
+                datetime(2024, 1, 1),
+                datetime(2024, 1, 2),
+                datetime(2024, 1, 3),
+                datetime(2024, 1, 4),
+                datetime(2024, 1, 5),
+                datetime(2024, 1, 6),
+                datetime(2024, 1, 7),
+                datetime(2024, 1, 8),
+                datetime(2024, 1, 9),
+                datetime(2024, 1, 10)
+            ],
+            "colA": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "colB": [1, 2, 3, 4, 5, 6, 7, 9, 9, 10],
+            "colC": [2, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        })
+
+        assert_frame_equal(ts.df, expected)


### PR DESCRIPTION
Although we want to avoid having data with rows that have duplicate time stamps (by tightening up the ingestors), these duplicates are slipping through and causing the API (and the UI) to fail because at the minute, any duplicate time stamps will cause the TimeSeries class to fail the Periodicity check.

This PR adds in the option for user to decide what to do if duplicates are found:
Current options:
        - "error": Raise an error if duplicate rows are found.
        - "keep_first": Keep the first row of any duplicate groups.
        - "keep_last": Keep the last row of any duplicate groups.
        - "drop": Drop all duplicate rows.
        - "merge": Merge duplicate rows using "coalesce" (the first non-null value for each column takes precedence).


