### PR TITLE
FPM-286: Pad missing rows

### DIFF
--- a/docs/source/user_guide/timeseries_basics.rst
+++ b/docs/source/user_guide/timeseries_basics.rst
@@ -254,6 +254,43 @@ approach that preserves the first non-null value for each column.
    import examples_timeseries_basics
    ts = examples_timeseries_basics.aggregation_duplicate_row_example_merge()
 
+Missing Rows
+------------
+The ``TimeSeries`` class provides functionality to automatically pad missing time points within a time series,
+ensuring complete temporal coverage without gaps. Consider daily data with some missing days:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_33]
+   :end-before: [end_block_33]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.create_df_with_missing_rows()
+
+The padding is controlled by the pad parameter during ``TimeSeries`` initialisation:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_timeseries_basics.py
+   :language: python
+   :start-after: [start_block_34]
+   :end-before: [end_block_34]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_timeseries_basics
+   ts = examples_timeseries_basics.pad_timeseries()
+
+.. warning::
+    It is very important to set the ``periodicity`` and ``resolution`` parameters if you want to pad your data.
+    Otherwise, the padding process will use the default periods of 1 microsecond, and try to pad your entire dataset
+    with microsecond data, which will almost definitely result in a memory error!
+
+
 Accessing Data
 -------------
 

--- a/src/time_stream/examples/examples_timeseries_basics.py
+++ b/src/time_stream/examples/examples_timeseries_basics.py
@@ -640,3 +640,44 @@ def aggregation_duplicate_row_example_merge():
 
     print(ts)
     # [end_block_32]
+
+def create_df_with_missing_rows():
+    # [start_block_33]
+    # Create sample data with gaps
+    dates = [
+        datetime(2023, 1, 1),
+        datetime(2023, 1, 3),
+        datetime(2023, 1, 4),
+        datetime(2023, 1, 5),
+        datetime(2023, 1, 7),
+    ]
+    temperatures = [20, 19, 26, 24, 26]
+    precipitation = [0, 5, 10, 2, 0]
+
+    df = pl.DataFrame({
+        "timestamp": dates,
+        "temperature": temperatures,
+        "precipitation": precipitation
+    })
+
+    print(df)
+    # [end_block_33]
+    return df
+
+
+def pad_timeseries():
+    with suppress_output():
+        df = create_df_with_missing_rows()
+
+    # [start_block_34]
+    # Merges groups of duplicate rows
+    ts = TimeSeries(
+        df=df,
+        time_name="timestamp",
+        resolution=Period.of_days(1),
+        periodicity=Period.of_days(1),
+        pad=True  # Enable padding
+    )
+
+    print(ts)
+    # [end_block_34]


### PR DESCRIPTION
Adds a new optional argument to the TimeSeries init for users to "pad" their data, in case of missing time stamps.  

This procedure respects the periodicity and resolution parameters, getting any missing rows by building an "expected" series of time stamps that we would expect if the time series was full.  Then compares this to the "actual" series, and adds in any missing.  Other columns are set to NULL. 