### PR TITLE
FPM-234 - Add non-epoch agnostic check to aggregation period

### DIFF
--- a/src/time_stream/aggregation.py
+++ b/src/time_stream/aggregation.py
@@ -67,6 +67,11 @@ class PolarsAggregator:
         Returns:
             A DataFrame containing the aggregated data
         """
+        # Check aggregation period
+        if not self.aggregation_period.is_epoch_agnostic():
+            # E.g. 5 hours, 7 days, 9 months, etc.
+            raise NotImplementedError("Aggregation not available for non-epoch agnostic periodicity")
+
         aggregation_expression_list: list[pl.Expr] = []
         unnest_list: list[str] = []
         with_column_list: list[pl.Expr] = []

--- a/tests/time_stream/test_aggregation.py
+++ b/tests/time_stream/test_aggregation.py
@@ -529,6 +529,31 @@ class TestFunctions(unittest.TestCase):
             value_fn=_get_max_list,
         )
 
+    @parameterized.expand(
+        [
+            Period.of_hours(5),
+            Period.of_days(7),
+            Period.of_months(9),
+        ]
+    )
+    def test_with_non_epoch_agnostic_periods(self, aggregation_period):
+        """ Test that the aggregation fails to run if the aggregation period is not an epoch-agnostic period
+        """
+        df = pl.DataFrame({
+            "timestamp": [datetime(2023, 1, 1, 1, min) for min in range(1, 11)],
+            "values": (range(10))
+        })
+
+        ts = TimeSeries(
+            df=df,
+            time_name="timestamp",
+            resolution=Period.of_minutes(1),
+            periodicity=Period.of_minutes(1),
+        )
+
+        with self.assertRaises(NotImplementedError):
+            ts.aggregate(aggregation_period, "mean", "values")
+
 class TestSubPeriodCheck(unittest.TestCase):
     """Test the "periodicity is a subperiod of aggregation period" check"""
     df = pl.DataFrame({


### PR DESCRIPTION
Preivously, aggregation stage would run even if the chosen Period was "non-epoch agnostic", e.g. P5M or P10Y.  However, it would eventually fail when building the output TimeSeries object, because there is validation within that class to do with checking epoch agnostic periods. 

This PR adds a check before the aggregation occurs, and raise error early if the aggregation period is non-epoch agnastic. 

Future work could look into whether it makes sense to allow non-epoch agnostic periods. 