### PR TITLE
Add noqa for some ruff warnings.

### DIFF
--- a/src/time_stream/__init__.py
+++ b/src/time_stream/__init__.py
@@ -28,12 +28,12 @@ def __getattr__(name: str) -> Any:
     #   dependencies being loaded at startup and also gives us control over what to expose from the package.
 
     if name == "TimeSeries":
-        from time_stream.base import TimeSeries
+        from time_stream.base import TimeSeries  # noqa: PLC0415
 
         return TimeSeries
 
     if name == "Period":
-        from time_stream.period import Period
+        from time_stream.period import Period  # noqa: PLC0415
 
         return Period
 

--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -12,7 +12,7 @@ from time_stream.period import Period
 from time_stream.relationships import RelationshipManager
 
 
-class TimeSeries:
+class TimeSeries:  # noqa: PLW1641 ignore hash warning
     """A class representing a time series data model, with data held in a Polars DataFrame."""
 
     def __init__(

--- a/src/time_stream/columns.py
+++ b/src/time_stream/columns.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from time_stream import TimeSeries
 
 
-class TimeSeriesColumn(ABC):
+class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
     """Base class for all column types in a TimeSeries."""
 
     def __init__(self, name: str, ts: "TimeSeries", metadata: Optional[Dict[str, Any]] = None) -> None:


### PR DESCRIPTION
New version of ruff introduced some new warnings.  Have ignored them for now with `#noqa` comments.  I don't think we need to address them anyway.