### PR TITLE
FPM-510 time range check

### DIFF
--- a/docs/source/user_guide/quality_control.rst
+++ b/docs/source/user_guide/quality_control.rst
@@ -132,8 +132,15 @@ Time Range Check
 Flags values in the ``TimeSeries`` outside or within a specified time range in the ``TimeSeries``
 primary time column.
 
-This is useful for scenarios where there are consistent errors at a certain time of day, for example, during an
-automated sensor calibration time.
+This can either be used with min / max values of:
+
+- ``datetime.time`` : Useful for scenarios where there are consistent errors at a certain time of day,
+  e.g., during an automated sensor calibration time.
+
+- ``datetime.date`` : Useful for scenarios where a specific date range is known to be bad,
+  e.g., during a date range of known sensor malfunction.
+
+- ``datetime.datetime`` : As above, but where there you need to add a time to the date range as well.
 
 **Name**: ``"time_range"``
 
@@ -157,6 +164,35 @@ Examples
 
    import examples_quality_control
    ts = examples_quality_control.time_range_qc_1()
+
+**2. Flag values between 03:30 on the 1st January and 09:30 on the 1st January**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+   :language: python
+   :start-after: [start_block_10]
+   :end-before: [end_block_10]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_quality_control
+   ts = examples_quality_control.time_range_qc_2()
+
+
+**3. Flag values between 1st January and the 2nd January**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+   :language: python
+   :start-after: [start_block_11]
+   :end-before: [end_block_11]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_quality_control
+   ts = examples_quality_control.time_range_qc_3()
 
 Spike Check
 ~~~~~~~~~~~~~

--- a/docs/source/user_guide/quality_control.rst
+++ b/docs/source/user_guide/quality_control.rst
@@ -127,6 +127,37 @@ Examples
    import examples_quality_control
    ts = examples_quality_control.range_qc_2()
 
+Time Range Check
+~~~~~~~~~~~~~
+Flags values in the ``TimeSeries`` outside or within a specified time range in the ``TimeSeries``
+primary time column.
+
+This is useful for scenarios where there are consistent errors at a certain time of day, for example, during an
+automated sensor calibration time.
+
+**Name**: ``"time_range"``
+
+.. note::
+    This is equivalent to using ``RangeCheck`` with ``check_column = ts.time_name``. This is a
+    convenience method to be explicit that we are working with the primary time column in the ``TimeSeries`` object.
+
+Examples
+^^^^^^^^^^^^^
+
+**1. Flag values between the hours of 01:00 and 03:00**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+   :language: python
+   :start-after: [start_block_9]
+   :end-before: [end_block_9]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_quality_control
+   ts = examples_quality_control.time_range_qc_1()
+
 Spike Check
 ~~~~~~~~~~~~~
 

--- a/src/time_stream/enums.py
+++ b/src/time_stream/enums.py
@@ -77,3 +77,19 @@ class MissingCriteria(Enum):
     MISSING = "missing"
     AVAILABLE = "available"
     NA = "na"
+
+
+class ClosedInterval(Enum):
+    """Enum representing how to handle the edges of intervals
+
+    Attributes:
+        BOTH: Both edges are considered closed (inclusive)
+        LEFT: Only the left edge is considered closed (left inclusive, right exclusive)
+        RIGHT: Only the right edge is considered closed (left exclusive, right inclusive)
+        NONE: Neither edge is considered closed (exclusive)
+    """
+
+    BOTH = "both"
+    LEFT = "left"
+    RIGHT = "right"
+    NONE = "none"

--- a/src/time_stream/examples/examples_quality_control.py
+++ b/src/time_stream/examples/examples_quality_control.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, time
+from datetime import datetime, date, timedelta, time
 
 import polars as pl
 
@@ -178,3 +178,39 @@ def time_range_qc_1():
 
     print(ts)
     # [end_block_9]
+
+
+def time_range_qc_2():
+    with suppress_output():
+        ts = create_simple_time_series()
+
+    # [start_block_10]
+    ts.df = ts.df.with_columns(
+        ts.qc_check(
+            "time_range",
+            check_column="temperature",
+            min_value=datetime(2023, 1, 1, 3, 30),
+            max_value=datetime(2023, 1, 1, 9, 30),
+        ).alias("qc_result")
+    )
+
+    print(ts)
+    # [end_block_10]
+
+
+def time_range_qc_3():
+    with suppress_output():
+        ts = create_simple_time_series()
+
+    # [start_block_11]
+    ts.df = ts.df.with_columns(
+        ts.qc_check(
+            "time_range",
+            check_column="temperature",
+            min_value=date(2023, 1, 1),
+            max_value=date(2023, 1, 2),
+        ).alias("qc_result")
+    )
+
+    print(ts)
+    # [end_block_11]

--- a/src/time_stream/examples/examples_quality_control.py
+++ b/src/time_stream/examples/examples_quality_control.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 
 import polars as pl
 
@@ -10,7 +10,7 @@ from utils import suppress_output
 
 def create_simple_time_series():
     # [start_block_1]
-    dates = [datetime(2023, 1, 1) + timedelta(days=i) for i in range(10)]
+    dates = [datetime(2023, 1, 1) + timedelta(hours=i) for i in range(10)]
     temperatures = [24, 22, -35, 26, 24, 26, 28, 50, 52, 29]
     precipitation = [-3, 0, 5, 10, 2, 0, 0, 3, 1, 0]
     sensor_codes = [992, 1, 1, 1, 1, 1, 1, 991, 995, 1]
@@ -27,6 +27,9 @@ def create_simple_time_series():
         time_name="timestamp"
     )
     # [end_block_1]
+    with pl.Config(tbl_rows=-1):
+        print(ts)
+
     return ts
 
 def comparison_qc_1():
@@ -91,7 +94,7 @@ def range_qc_1():
             check_column="temperature",
             min_value=-10,
             max_value=50,
-            inclusive=False,  # Range is not inclusive of min and max value
+            closed="none",  # Range is not inclusive of min and max value
             within=False, # Flag values outside of this range
         ).alias("qc_result")
     )
@@ -110,7 +113,7 @@ def range_qc_2():
             check_column="precipitation",
             min_value=-3,
             max_value=1,
-            inclusive=True,  # Range is inclusive of min and max value
+            closed="both",  # Range is inclusive of min and max value
             within=True, # Flag values inside of this range
         ).alias("qc_result")
     )
@@ -149,7 +152,7 @@ def observation_interval_example():
             check_column="temperature",
             min_value=-10,
             max_value=50,
-            inclusive=False,
+            closed="none",
             within=False,
             observation_interval=(start_date, end_date)
         ).alias("qc_result")
@@ -157,3 +160,21 @@ def observation_interval_example():
 
     print(ts)
     # [end_block_8]
+
+
+def time_range_qc_1():
+    with suppress_output():
+        ts = create_simple_time_series()
+
+    # [start_block_9]
+    ts.df = ts.df.with_columns(
+        ts.qc_check(
+            "time_range",
+            check_column="temperature",
+            min_value=time(1, 0),
+            max_value=time(3, 0)
+        ).alias("qc_result")
+    )
+
+    print(ts)
+    # [end_block_9]

--- a/tests/time_stream/test_qc.py
+++ b/tests/time_stream/test_qc.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 from polars.testing import assert_series_equal
 
 from time_stream.base import TimeSeries
-from time_stream.qc import QCCheck, ComparisonCheck, SpikeCheck, RangeCheck
+from time_stream.qc import QCCheck, ComparisonCheck, SpikeCheck, RangeCheck, TimeRangeCheck
 
 
 class MockQC(QCCheck):
@@ -183,6 +183,8 @@ class TestRangeCheck(unittest.TestCase):
     def setUp(self):
         data = pl.DataFrame({
             "time": [
+                datetime(2023, 8, 9, 23, 0),
+                datetime(2023, 8, 9, 23, 30),
                 datetime(2023, 8, 10, 0, 0),
                 datetime(2023, 8, 10, 0, 30),
                 datetime(2023, 8, 10, 1, 0),
@@ -190,84 +192,104 @@ class TestRangeCheck(unittest.TestCase):
                 datetime(2023, 8, 10, 2, 0),
                 datetime(2023, 8, 10, 2, 30),
             ],
-            "value_a": range(6)
+            "value_a": range(8)
         })
         self.ts = TimeSeries(data, "time")
 
-    def test_range_check(self):
-        """ Test that the range check returns expected results when some values outside of range
+    @parameterized.expand([
+        # min, max, closed, within, expected
+        ("distinct_flag_within", 0.5, 3.5, "both", True, [False, True, True, True, False, False, False, False]),
+        ("distinct_flag_outside", 0.5, 3.5, "both", False, [True, False, False, False, True, True, True, True]),
+        ("all_within_flag_within", -1, 10, "both", True, [True, True, True, True, True, True, True, True]),
+        ("all_within_flag_outside", -1, 10, "both", False, [False, False, False, False, False, False, False, False]),
+        ("all_outside_flag_within", 90, 100, "both", True, [False, False, False, False, False, False, False, False]),
+        ("all_outside_flag_outside", 90, 100, "both", False, [True, True, True, True, True, True, True, True]),
+    ])
+    def test_range_check(self, _, min_value, max_value, closed, within, expected):
+        """ Test that the range-check returns expected results
         """
-        check = RangeCheck(0.5, 3.5)
+        check = RangeCheck(min_value, max_value, closed, within)
         result = check.apply(self.ts, "value_a")
-        expected = pl.Series([True, False, False, False, True, True])
-        assert_series_equal(result, expected)
+        assert_series_equal(result, pl.Series(expected))
 
-    def test_range_check_within(self):
-        """ Test that the range check returns expected results with the within parameter set.
+    @parameterized.expand([
+        # min, max, closed, within, expected
+        ("closed_both_flag_within", 1, 3, "both", True, [False, True, True, True, False, False, False, False]),
+        ("closed_both_flag_outside", 1, 3, "both", False, [True, False, False, False, True, True, True, True]),
+        ("closed_left_flag_within", 1, 3, "left", True, [False, True, True, False, False, False, False, False]),
+        ("closed_left_flag_outside", 1, 3, "left", False, [True, False, False, True, True, True, True, True]),
+        ("closed_right_flag_within", 1, 3, "right", True, [False, False, True, True, False, False, False, False]),
+        ("closed_right_flag_outside", 1, 3, "right", False, [True, True, False, False, True, True, True, True]),
+        ("closed_none_flag_within", 1, 3, "none", True, [False, False, True, False, False, False, False, False]),
+        ("closed_none_flag_outside", 1, 3, "none", False, [True, True, False, True, True, True, True, True]),
+    ])
+    def test_range_check_at_values(self, _, min_value, max_value, closed, within, expected):
+        """ Test that the range-check returns expected results when the min and max values are exact values
+        in the time series.  This is intended to test the "closed" parameter.
         """
-        check = RangeCheck(0.5, 3.5, within=True)
+        check = RangeCheck(min_value, max_value, closed, within)
         result = check.apply(self.ts, "value_a")
-        expected = pl.Series([False, True, True, True, False, False])
-        assert_series_equal(result, expected)
+        assert_series_equal(result, pl.Series(expected))
 
-    def test_range_check_all_within(self):
-        """ Test that the range check returns expected results when all values within range
-        """
-        check = RangeCheck(-1, 10)
-        result = check.apply(self.ts, "value_a")
-        expected = pl.Series([False, False, False, False, False, False])
-        assert_series_equal(result, expected)
+    @parameterized.expand([
+        # min, max, closed, within, expected
+        ("distinct_flag_within", time(0, 15), time(1, 45), "both", True,
+         [False, False, False, True, True, True, False, False]),
 
-    def test_range_check_all_outside(self):
-        """ Test that the range check returns expected results when all values within range
-        """
-        check = RangeCheck(90, 100)
-        result = check.apply(self.ts, "value_a")
-        expected = pl.Series([True, True, True, True, True, True])
-        assert_series_equal(result, expected)
+        ("distinct_flag_outside", time(0, 15), time(1, 45), "both", False,
+         [True, True, True, False, False, False, True, True]),
 
-    def test_range_check_at_boundaries_inclusive(self):
-        """ Test that the range check returns expected results when values at boundaries, with the
-        inclusive option set to True
-        """
-        check = RangeCheck(0., 5., inclusive=True)
-        result = check.apply(self.ts, "value_a")
-        expected = pl.Series([False, False, False, False, False, False])
-        assert_series_equal(result, expected)
+        ("all_outside_flag_within", time(3, 0), time(12, 0), "both", True,
+         [False, False, False, False, False, False, False, False]),
 
-    def test_range_check_at_boundaries_non_inclusive(self):
-        """ Test that the range check returns expected results when values at boundaries, with the
-        inclusive option set to False.
-        """
-        check = RangeCheck(0., 5., inclusive=False)
-        result = check.apply(self.ts, "value_a")
-        expected = pl.Series([True, False, False, False, False, True])
-        assert_series_equal(result, expected)
-
-    def test_range_check_using_time(self):
+        ("all_outside_flag_outside", time(3, 0), time(12, 0), "both", False,
+         [True, True, True, True, True, True, True, True]),
+    ])
+    def test_range_check_using_time(self, _, min_value, max_value, closed, within, expected):
         """ Test that the range check accepts time values.
         """
-        check = RangeCheck(time(0, 30), time(1, 30))
+        check = RangeCheck(min_value, max_value, closed, within)
         result = check.apply(self.ts, "time")
-        expected = pl.Series([True, False, False, False, True, True])
-        assert_series_equal(result, expected)
+        assert_series_equal(result, pl.Series(expected))
 
-    def test_range_check_using_time_within(self):
-        """ Test that the range check works with time values, with the within parameter set to True.
-        """
-        check = RangeCheck(time(0, 30), time(1, 30), within=True)
-        result = check.apply(self.ts, "time")
-        expected = pl.Series([False, True, True, True, False, False])
-        assert_series_equal(result, expected)
+    @parameterized.expand([
+        # min_time, max_time, inclusive, within, expected
+        ("all_within_flag_within", time(22, 0), time(3, 0), "both", True,
+         [True, True, True, True, True, True, True, True]),
 
-    def test_range_check_using_time_non_inclusive(self):
-        """ Test that the range check works with time values, with the within parameter set to True,
-        and inclusive set to False.
+        ("all_within_flag_outside", time(22, 0), time(3, 0), "both", False,
+         [False, False, False, False, False, False, False, False]),
+
+        ("closed_both_flag_within", time(23, 30), time(1, 30), "both", True,
+         [False, True, True, True, True, True, False, False]),
+
+        ("closed_both_flag_outside", time(23, 30), time(1, 30), "both", False,
+         [True, False, False, False, False, False, True, True]),
+
+        ("closed_left_flag_within", time(23, 30), time(1, 30), "left", True,
+         [False, True, True, True, True, False, False, False]),
+
+        ("closed_left_flag_outside", time(23, 30), time(1, 30), "left", False,
+         [True, False, False, False, False, True, True, True]),
+
+        ("closed_right_flag_within", time(23, 30), time(1, 30), "right", True,
+         [False, False, True, True, True, True, False, False]),
+
+        ("closed_right_flag_outside", time(23, 30), time(1, 30), "right", False,
+         [True, True, False, False, False, False, True, True]),
+
+        ("closed_none_flag_within", time(23, 30), time(1, 30), "none", True,
+         [False, False, True, True, True, False, False, False]),
+
+        ("closed_none_flag_outside", time(23, 30), time(1, 30), "none", False,
+         [True, True, False, False, False, True, True, True]),
+    ])
+    def test_time_range_check_across_midnight(self, _, min_value, max_value, closed, within, expected):
+        """ Test that the time range check works as expected when the range is across midnight
         """
-        check = RangeCheck(time(0, 30), time(1, 30), within=True, inclusive=False)
+        check = RangeCheck(min_value, max_value, closed, within)
         result = check.apply(self.ts, "time")
-        expected = pl.Series([False, False, True, False, False, False])
-        assert_series_equal(result, expected)
+        assert_series_equal(result, pl.Series(expected))
 
 
 class TestSpikeCheck(unittest.TestCase):


### PR DESCRIPTION
The QC range function checks whether the given column is between (or outside of) given min and max values. 

There was already consideration for if the check was being done with **time** min and max values - in which case the pl.col was initialised with `pl.col(check_column).dt.time()`.  

This is all fine, however in implementing this in the FDRI processing pipeline, an issue arose in that the check_column was being passed as e.g. "temperature", but the check actually needed to be done on the primary datetime column of the time series. 

### Main change

To be explicit about range checks that are to be done on the primary datetime column, I've added a sub-class to the range check: `TimeRangeCheck`.  All this does is override the `expr` method to explicitly set the check_column to the ts.time_name. 

### Sub changes

#### Closed interval
To be more familiar to polars users, swapped the `inclusive` parameter for a `closed` parameter, using the same enum values that polars does: {both, left, right, none}.  

#### Use of `is_between`
The logic of setting up the range check has been simplified to use the polars `is_between` method

#### Time check spanning midnight
In doing this and thinking more about unit tests, it became clear that we needed something to handle time ranges that span across midnight.  The current time range check wasn't sufficient because the min value would be technically larger than the max value, e.g. consider wanting to flag all values between the hours of 11pm and 1am.  

#### Explicit date range check
Added in handling of datetime.date objects, which flag all values from the provided dates