### PR TITLE
Refactor: Add consistency to type hints using latest PEP recommendations

### DIFF
--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -1,7 +1,7 @@
 from collections import Counter
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Type
 
 import polars as pl
 
@@ -25,15 +25,15 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         self,
         df: pl.DataFrame,
         time_name: str,
-        resolution: Optional[Period | str] = None,
-        periodicity: Optional[Period | str] = None,
-        supplementary_columns: Optional[list] = None,
-        flag_systems: Optional[Union[Dict[str, dict], Dict[str, Type[Enum]]]] = None,
-        flag_columns: Optional[Dict[str, str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        column_metadata: Optional[Dict[str, Dict[str, Any]]] = None,
-        on_duplicates: Optional[Union[DuplicateOption, str]] = DuplicateOption.ERROR,
-        pad: Optional[bool] = False,
+        resolution: Period | str | None = None,
+        periodicity: Period | str | None = None,
+        supplementary_columns: list | None = None,
+        flag_systems: dict[str, dict] | dict[str, Type[Enum]] | None = None,
+        flag_columns: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        column_metadata: dict[str, dict[str, Any]] | None = None,
+        on_duplicates: DuplicateOption | str = DuplicateOption.ERROR,
+        pad: bool = False,
     ) -> None:
         """Initialise a TimeSeries instance.
 
@@ -67,7 +67,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def _setup(
         self,
-        supplementary_columns: List[str],
+        supplementary_columns: list[str],
         flag_columns: dict[str, str],
         column_metadata: dict[str, dict[str, Any]],
         metadata: dict[str, Any],
@@ -104,7 +104,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def _setup_columns(
         self,
-        supplementary_columns: List[str] = None,
+        supplementary_columns: list[str] = None,
         flag_columns: dict[str, str] = None,
         column_metadata: dict[str, dict[str, Any]] = None,
     ) -> None:
@@ -492,7 +492,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         columns = {col.name: col for col in self._columns.values() if type(col) is not PrimaryTimeColumn}
         return columns
 
-    def select(self, col_names: List[str]) -> "TimeSeries":
+    def select(self, col_names: list[str]) -> "TimeSeries":
         """Filter TimeSeries instance to include only the specified columns.
 
         Args:
@@ -534,8 +534,8 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
     def init_supplementary_column(
         self,
         col_name: str,
-        data: Optional[Union[int, float, str, Iterable]] = None,
-        dtype: Optional[pl.DataType] = None,
+        data: int | float | str | Iterable | None = None,
+        dtype: pl.DataType | None = None,
     ) -> None:
         """Add a new column to the TimeSeries DataFrame, marking it as a supplementary column.
 
@@ -564,7 +564,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         supplementary_col = SupplementaryColumn(col_name, self)
         self._columns[col_name] = supplementary_col
 
-    def set_supplementary_column(self, col_name: Union[str, List[str]]) -> None:
+    def set_supplementary_column(self, col_name: str | list[str]) -> None:
         """Mark the specified existing column(s) as a supplementary column.
 
         Args:
@@ -579,9 +579,9 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
     def aggregate(
         self,
         aggregation_period: Period,
-        aggregation_function: Union[str, Type["AggregationFunction"], "AggregationFunction"],
-        columns: Union[str, List[str]],
-        missing_criteria: Optional[Tuple[str, Union[float, int]]] = None,
+        aggregation_function: str | Type["AggregationFunction"] | AggregationFunction,
+        columns: str | list[str],
+        missing_criteria: tuple[str, float | int] | None = None,
     ) -> "TimeSeries":
         """Apply an aggregation function to a column in this TimeSeries, check the aggregation satisfies user
         requirements and return a new derived TimeSeries containing the aggregated data.
@@ -604,9 +604,9 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def qc_check(
         self,
-        check: Union[str, "QCCheck", Type["QCCheck"]],
+        check: str | Type["QCCheck"] | QCCheck,
         check_column: str,
-        observation_interval: Optional[Tuple[datetime, Optional[datetime]]] = None,
+        observation_interval: tuple[datetime, datetime | None] | None = None,
         **kwargs,
     ) -> pl.Series:
         """Apply a quality control check to the TimeSeries.
@@ -642,10 +642,10 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def infill(
         self,
-        infill_method: Union[str, Type["InfillMethod"], "InfillMethod"],
+        infill_method: str | Type["InfillMethod"] | InfillMethod,
         column: str,
-        observation_interval: Optional[Tuple[datetime, Optional[datetime]]] = None,
-        max_gap_size: Optional[int] = None,
+        observation_interval: tuple[datetime, datetime | None] | None = None,
+        max_gap_size: int | None = None,
         **kwargs,
     ) -> "TimeSeries":
         """Apply an infilling method to a column in the TimeSeries to fill in missing data.
@@ -668,7 +668,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         infill_instance = InfillMethod.get(infill_method, **kwargs)
         return infill_instance.apply(self, column, observation_interval, max_gap_size)
 
-    def metadata(self, key: Optional[Sequence[str]] = None, strict: bool = True) -> Dict[str, Any]:
+    def metadata(self, key: str | list[str] | None = None, strict: bool = True) -> dict[str, Any]:
         """Retrieve metadata for all or specific keys.
 
         Args:
@@ -695,8 +695,8 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         return result
 
     def column_metadata(
-        self, column: Optional[Union[str, Sequence[str]]] = None, key: Optional[Union[str, Sequence[str]]] = None
-    ) -> Dict[str, Dict[str, Any]]:
+        self, column: str | list[str] | None = None, key: str | list[str] | None = None
+    ) -> dict[str, dict[str, Any]]:
         """Retrieve metadata for a given column(s), for all or specific keys.
 
         Args:
@@ -731,7 +731,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
         return result
 
-    def add_column_relationship(self, primary: str, other: Union[str, List[str]]) -> None:
+    def add_column_relationship(self, primary: str, other: str | list[str]) -> None:
         """Adds a relationship between the primary column and other column(s).
 
         Args:
@@ -744,7 +744,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         primary = self.columns[primary]
         primary.add_relationship(other)
 
-    def remove_column_relationship(self, primary: str, other: Union[str, List[str]]) -> None:
+    def remove_column_relationship(self, primary: str, other: str | list[str]) -> None:
         """Removes a relationship between the primary column and other column(s).
 
         Args:
@@ -758,9 +758,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         for other_column in other:
             primary.remove_relationship(other_column)
 
-    def get_flag_system_column(
-        self, data_column: Union[str, TimeSeriesColumn], flag_system: str
-    ) -> Optional["TimeSeriesColumn"]:
+    def get_flag_system_column(self, data_column: str | TimeSeriesColumn, flag_system: str) -> TimeSeriesColumn | None:
         """Retrieves the flag system column corresponding to the given data column and flag system.
 
         Args:
@@ -837,7 +835,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         except (KeyError, AttributeError):
             raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
-    def __getitem__(self, key: Union[str, List[str], tuple[str]]) -> Union["TimeSeries", PrimaryTimeColumn]:
+    def __getitem__(self, key: str | Iterable[str]) -> "TimeSeries | PrimaryTimeColumn":
         """Access columns or the time column using indexing syntax.
 
         This method enables convenient access to DataFrame columns or the time column by using indexing. It supports:
@@ -897,7 +895,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
             f"flag_columns={list(self.flag_columns.keys())}, "
         )
 
-    def __dir__(self) -> List[str]:
+    def __dir__(self) -> list[str]:
         """Return a list of attributes associated with the TimeSeries class.
 
         This method extends the default attributes of the TimeSeries class by including the column names of the

--- a/src/time_stream/bitwise.py
+++ b/src/time_stream/bitwise.py
@@ -1,5 +1,4 @@
 from enum import EnumType, Flag
-from typing import Union
 
 
 class BitwiseMeta(EnumType):
@@ -68,7 +67,7 @@ class BitwiseFlag(int, Flag, metaclass=BitwiseMeta):
             raise ValueError(f"Flag is not unique: {value}")
 
     @classmethod
-    def get_single_flag(cls, flag: Union[int, str]) -> "BitwiseFlag":
+    def get_single_flag(cls, flag: int | str) -> "BitwiseFlag":
         """Retrieves a single flag from an integer or string value.
 
         Can't be a combination of integer flag values, for example with the classification of:

--- a/src/time_stream/columns.py
+++ b/src/time_stream/columns.py
@@ -1,6 +1,6 @@
 import copy
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Sequence, Type
 
 import polars as pl
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
     """Base class for all column types in a TimeSeries."""
 
-    def __init__(self, name: str, ts: "TimeSeries", metadata: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, name: str, ts: "TimeSeries", metadata: dict[str, Any] | None = None) -> None:
         """Initializes a TimeSeriesColumn instance.
 
         Args:
@@ -49,7 +49,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         if self.name not in self._ts.df.columns:
             raise ValueError(f"Column '{self.name}' not found in TimeSeries.")
 
-    def metadata(self, key: Optional[Sequence[str]] = None, strict: bool = True) -> Dict[str, Any]:
+    def metadata(self, key: Sequence[str] = None, strict: bool = True) -> dict[str, Any]:
         """Retrieve metadata for all or specific keys.
 
         Args:
@@ -75,7 +75,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
             result[k] = value
         return result
 
-    def remove_metadata(self, key: Optional[Union[str, list[str], tuple[str, ...]]] = None) -> None:
+    def remove_metadata(self, key: str | list[str] | tuple[str, ...] | None = None) -> None:
         """Removes metadata associated with a column, either completely or for specific keys.
 
         Args:
@@ -91,8 +91,8 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
 
     def _set_as(
         self,
-        column_type: "Type[TimeSeriesColumn]",
-        related_columns: Optional[Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]] = None,
+        column_type: Type["TimeSeriesColumn"],
+        related_columns: "str | TimeSeriesColumn | list[TimeSeriesColumn | str] | None" = None,
         *args,
         **kwargs,
     ) -> "TimeSeriesColumn":
@@ -124,7 +124,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         return column
 
     def set_as_supplementary(
-        self, related_columns: Optional[Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]] = None
+        self, related_columns: "str | TimeSeriesColumn | list[TimeSeriesColumn | str] | None" = None
     ) -> "TimeSeriesColumn":
         """Converts the column to a SupplementaryColumn while preserving metadata.
 
@@ -142,7 +142,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
     def set_as_flag(
         self,
         flag_system: str,
-        related_columns: Optional[Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]] = None,
+        related_columns: "str | TimeSeriesColumn | list[TimeSeriesColumn | str] | None" = None,
     ) -> "TimeSeriesColumn":
         """Converts the column to a FlagColumn while preserving metadata.
 
@@ -235,7 +235,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         return self._ts.select([self.name])
 
     @abstractmethod
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Defines relationships between columns.
 
         Args:
@@ -243,7 +243,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         """
         pass
 
-    def remove_relationship(self, other: Union["TimeSeriesColumn", str]) -> None:
+    def remove_relationship(self, other: "TimeSeriesColumn | str") -> None:
         """Remove relationships between columns.
 
         Args:
@@ -404,7 +404,7 @@ class PrimaryTimeColumn(TimeSeriesColumn):
 class DataColumn(TimeSeriesColumn):
     """Represents primary data columns."""
 
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Adds a relationship between this data column and supplementary or flag column(s).
 
         Args:
@@ -428,7 +428,7 @@ class DataColumn(TimeSeriesColumn):
 
             self._ts._relationship_manager._add(relationship)
 
-    def get_flag_system_column(self, flag_system: str) -> Optional["TimeSeriesColumn"]:
+    def get_flag_system_column(self, flag_system: str) -> "TimeSeriesColumn | None":
         """Retrieves the flag column linked to this data column that corresponds to the specified flag system.
 
         Args:
@@ -459,7 +459,7 @@ class DataColumn(TimeSeriesColumn):
 class SupplementaryColumn(TimeSeriesColumn):
     """Represents supplementary columns (e.g., metadata, extra information)."""
 
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Adds a relationship between this supplementary column and data column(s).
 
         Args:
@@ -489,9 +489,7 @@ class FlagColumn(SupplementaryColumn):
     or other categorical flags. Flags are stored using bitwise operations for efficiency.
     """
 
-    def __init__(
-        self, name: str, ts: "TimeSeries", flag_system: str, metadata: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def __init__(self, name: str, ts: "TimeSeries", flag_system: str, metadata: dict[str, Any] | None = None) -> None:
         """
         Initializes a FlagColumn.
 
@@ -504,7 +502,7 @@ class FlagColumn(SupplementaryColumn):
         super().__init__(name, ts, metadata)
         self.flag_system = self._ts.flag_systems[flag_system]
 
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Adds a relationship between this flag column and data column(s).
 
         Args:
@@ -526,7 +524,7 @@ class FlagColumn(SupplementaryColumn):
 
             self._ts._relationship_manager._add(relationship)
 
-    def add_flag(self, flag: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def add_flag(self, flag: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """Adds a flag value to this FlagColumn using a bitwise OR operation.
 
         Args:
@@ -539,7 +537,7 @@ class FlagColumn(SupplementaryColumn):
             pl.when(expr).then(pl.col(self.name) | flag.value).otherwise(pl.col(self.name))
         )
 
-    def remove_flag(self, flag: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def remove_flag(self, flag: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """Remove a flag value from this FlagColumn using a bitwise AND operation.
 
         Args:

--- a/src/time_stream/flag_manager.py
+++ b/src/time_stream/flag_manager.py
@@ -1,5 +1,5 @@
 import enum
-from typing import TYPE_CHECKING, Sequence, Type, Union
+from typing import TYPE_CHECKING, Sequence, Type
 
 import polars as pl
 
@@ -28,7 +28,7 @@ class TimeSeriesFlagManager:
     def flag_systems(self) -> dict[str, Type[enum.Enum]]:
         return self._flag_systems
 
-    def _setup_flag_systems(self, flag_systems: dict[str, Union[dict[str, int], Type[enum.Enum]]] = None) -> None:
+    def _setup_flag_systems(self, flag_systems: dict[str, dict[str, int] | Type[enum.Enum]] | None = None) -> None:
         """Adds flag systems into the flag manager.
 
         Args:
@@ -38,7 +38,7 @@ class TimeSeriesFlagManager:
         for name, flag_system in flag_systems.items():
             self.add_flag_system(name, flag_system)
 
-    def add_flag_system(self, name: str, flag_system: Union[dict[str, int], Type[enum.Enum]]) -> None:
+    def add_flag_system(self, name: str, flag_system: dict[str, dict[str, int] | Type[enum.Enum]]) -> None:
         """Adds a flag system to the flag manager, which contains flag values and their meanings.
 
         A flag system can be used to create flag columns that are specific to a particular type of flag.
@@ -75,7 +75,7 @@ class TimeSeriesFlagManager:
         else:
             raise TypeError(f"Unknown type of flag system: {type(flag_system)}")
 
-    def init_flag_column(self, flag_system: str, col_name: str, data: Union[int, Sequence[int]] = 0) -> None:
+    def init_flag_column(self, flag_system: str, col_name: str, data: int | Sequence[int] = 0) -> None:
         """Add a new column to the TimeSeries DataFrame, setting it as a Flag Column.
 
         Args:
@@ -102,7 +102,7 @@ class TimeSeriesFlagManager:
         flag_col = FlagColumn(col_name, self._ts, flag_system)
         self._ts._columns[col_name] = flag_col
 
-    def set_flag_column(self, flag_system: str, col_name: Union[str, list[str]]) -> None:
+    def set_flag_column(self, flag_system: str, col_name: str | list[str]) -> None:
         """Mark the specified existing column(s) as a flag column.
 
         Args:
@@ -115,7 +115,7 @@ class TimeSeriesFlagManager:
         for col in col_name:
             self._ts.columns[col].set_as_flag(flag_system)
 
-    def add_flag(self, col_name: str, flag_value: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def add_flag(self, col_name: str, flag_value: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """Add flag value (if not there) to flag column, where expression is True.
 
         Args:
@@ -125,7 +125,7 @@ class TimeSeriesFlagManager:
         """
         self._ts.columns[col_name].add_flag(flag_value, expr)
 
-    def remove_flag(self, col_name: str, flag_value: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def remove_flag(self, col_name: str, flag_value: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """
         Remove flag value (if there) from flag column.
 

--- a/src/time_stream/infill.py
+++ b/src/time_stream/infill.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, Type
 
 import numpy as np
 import polars as pl
@@ -61,7 +61,7 @@ class InfillMethod(ABC):
         pass
 
     @classmethod
-    def get(cls, method: Union[str, Type["InfillMethod"]], **kwargs) -> "InfillMethod":
+    def get(cls, method: str | Type["InfillMethod"], **kwargs) -> "InfillMethod":
         """Factory method to get an infill method class instance from string names or class type.
 
         Args:
@@ -106,8 +106,8 @@ class InfillMethod(ABC):
         df: pl.DataFrame,
         time_name: str,
         infill_column: str,
-        observation_interval: Optional[datetime | Tuple[datetime, datetime | None]] = None,
-        max_gap_size: Optional[int] = None,
+        observation_interval: datetime | tuple[datetime, datetime | None] | None = None,
+        max_gap_size: int | None = None,
     ) -> bool:
         """Check if there is actually anything to infill in the provided dataframe, considering the maximum gap size
         and datetime observation interval constraints
@@ -142,8 +142,8 @@ class InfillMethod(ABC):
         self,
         ts: TimeSeries,
         infill_column: str,
-        observation_interval: Optional[datetime | Tuple[datetime, datetime | None]] = None,
-        max_gap_size: Optional[int] = None,
+        observation_interval: datetime | tuple[datetime, datetime | None] | None = None,
+        max_gap_size: int | None = None,
     ) -> "TimeSeries":
         """Apply the infill method to the TimeSeries.
 

--- a/src/time_stream/period.py
+++ b/src/time_stream/period.py
@@ -59,7 +59,6 @@ from dataclasses import (
 )
 from typing import (
     Any,
-    Optional,
     override,
 )
 
@@ -185,7 +184,7 @@ class DateTimeAdjusters:
     advance: Callable[[dt.datetime], dt.datetime]
 
     @staticmethod
-    def of_month_offset(month_offset: int) -> Optional["DateTimeAdjusters"]:
+    def of_month_offset(month_offset: int) -> "DateTimeAdjusters | None":
         """Return a DateTimeAdjusters object for a given month offset,
         or return None if the month offset is 0
 
@@ -210,7 +209,7 @@ class DateTimeAdjusters:
         )
 
     @staticmethod
-    def of_microsecond_offset(microsecond_offset: int) -> Optional["DateTimeAdjusters"]:
+    def of_microsecond_offset(microsecond_offset: int) -> "DateTimeAdjusters | None":
         """Return a DateTimeAdjusters object for a given microsecond offset,
         or return None if the microsecond offset is 0
 
@@ -544,7 +543,7 @@ def _fmt_tzdelta(delta: dt.timedelta) -> str:
     return f"{sign}{hours:02}:{minutes:02}"
 
 
-def _fmt_tzinfo(tz: Optional[dt.tzinfo]) -> str:
+def _fmt_tzinfo(tz: dt.tzinfo | None) -> str:
     """Convert an optional tzinfo object into a string that
     can be used to represent the timezone in an ISO 8601 format
 
@@ -688,7 +687,7 @@ class Properties:
     multiplier: int
     month_offset: int
     microsecond_offset: int
-    tzinfo: Optional[dt.tzinfo]
+    tzinfo: dt.tzinfo | None
     ordinal_shift: int
 
     @staticmethod
@@ -948,7 +947,7 @@ class Properties:
             ordinal_shift=0,
         ).normalise_offsets()
 
-    def with_tzinfo(self, tzinfo: Optional[dt.tzinfo]) -> "Properties":
+    def with_tzinfo(self, tzinfo: dt.tzinfo | None) -> "Properties":
         """Return a Properties object derived from this one with
         the given datetime tzinfo object (time zone)
 
@@ -1036,7 +1035,7 @@ class Properties:
             return _get_month_period_name(self.multiplier)
         raise AssertionError(f"Illegal step: {self.step}")
 
-    def get_timedelta(self) -> Optional[dt.timedelta]:
+    def get_timedelta(self) -> dt.timedelta | None:
         """Return a timedelta object that matches the duration
         of this period, or None if no such timedelta exists
 
@@ -1609,7 +1608,7 @@ class PeriodFields:
         return self.get_months_seconds().get_base_properties()
 
 
-def _str2int(num: Optional[str], default: int = 0) -> int:
+def _str2int(num: str | None, default: int = 0) -> int:
     """Convert string to int, None becomes 0 (or default if specified)
 
     Args:
@@ -1625,7 +1624,7 @@ def _str2int(num: Optional[str], default: int = 0) -> int:
     return default if num is None else int(num)
 
 
-def _str2microseconds(num: Optional[str], default: int = 0) -> int:
+def _str2microseconds(num: str | None, default: int = 0) -> int:
     """Convert string to microseconds, None becomes 0 (or default if specified)
 
     A seconds + microseconds string looks like "nn.uuu". This function
@@ -1918,7 +1917,7 @@ class Period(ABC):
         return self._properties.get_iso8601()
 
     @property
-    def tzinfo(self) -> Optional[dt.tzinfo]:
+    def tzinfo(self) -> dt.tzinfo | None:
         """Get the tzinfo property"""
         return self._properties.tzinfo
 
@@ -1959,7 +1958,7 @@ class Period(ABC):
         return self.ordinal(dt.datetime.max)
 
     @property
-    def timedelta(self) -> Optional[dt.timedelta]:
+    def timedelta(self) -> dt.timedelta | None:
         """A timedelta object that matches the duration
         of this period, or None if no such timedelta exists
 
@@ -2291,7 +2290,7 @@ class Period(ABC):
         """
         return _get_offset_period(self._properties.with_microsecond_offset(microsecond_amount))
 
-    def with_tzinfo(self, tzinfo: Optional[dt.tzinfo]) -> "Period":
+    def with_tzinfo(self, tzinfo: dt.tzinfo | None) -> "Period":
         """Return a Period derived from this one but with the
         specified tzinfo
 
@@ -2911,7 +2910,7 @@ class AwareMicroSecondPeriod(Period):
 
 
 def _get_period_tzinfo(
-    tzinfo: Optional[dt.tzinfo],
+    tzinfo: dt.tzinfo | None,
     properties: Properties,
     naive: Callable[[Properties], Period],
     aware: Callable[[Properties], Period],
@@ -3157,7 +3156,7 @@ def _time_match(prefix: str, matcher: re.Match[str]) -> dt.time:
     )
 
 
-def _timezone(utc_offset: Optional[str]) -> Optional[dt.tzinfo]:
+def _timezone(utc_offset: str | None) -> dt.tzinfo | None:
     """Convert an optional string into an optional tzinfo
     object
 
@@ -3183,7 +3182,7 @@ def _timezone(utc_offset: Optional[str]) -> Optional[dt.tzinfo]:
     return dt.timezone(dt.timedelta(seconds=seconds))
 
 
-def _tzinfo_match(prefix: str, matcher: re.Match[str]) -> Optional[dt.tzinfo]:
+def _tzinfo_match(prefix: str, matcher: re.Match[str]) -> dt.tzinfo | None:
     """Extract a tzinfo object out of a regular expression matcher that
     has parsed an ISO 8601 format datetime
 
@@ -3295,11 +3294,11 @@ def _match_repr(matcher: re.Match[str]) -> Period:
     """
     period_fields: PeriodFields = _period_match("period", matcher)
     offset: str = matcher.group("offset")
-    offset_period_fields: Optional[PeriodFields] = None
+    offset_period_fields: PeriodFields | None = None
     if offset == "+":
         offset_period_fields = _period_match("offset", matcher)
     zone: str = matcher.group("zone")
-    tzinfo: Optional[dt.tzinfo] = None
+    tzinfo: dt.tzinfo | None = None
     if zone is not None and len(zone) > 0:
         tzinfo = _timezone(zone)
     shift: str = matcher.group("shift")
@@ -3375,7 +3374,7 @@ _RE_REPR = re.compile(
 #            object created from the Pattern into an optional
 #            Period object.
 #
-_PARSERS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Optional[Period]]]] = [
+_PARSERS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Period | None]]] = [
     (_RE_PERIOD, _match_period),
     (_RE_PERIOD_OFFSET, _match_period_offset),
     (_RE_DATETIME_PERIOD, _match_datetime_period),
@@ -3383,7 +3382,7 @@ _PARSERS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Optional[Period]
 ]
 
 
-def _get_period(period_string: str) -> Optional[Period]:
+def _get_period(period_string: str) -> Period | None:
     """Return an optional Period object from a string
 
     Tries a number of possible string formats and returns
@@ -3395,9 +3394,9 @@ def _get_period(period_string: str) -> Optional[Period]:
         not be converted to a Period
     """
     regex: re.Pattern[str]
-    match_fn: Callable[[re.Match[str]], Optional[Period]]
+    match_fn: Callable[[re.Match[str]], Period | None]
     for regex, match_fn in _PARSERS:
-        matcher: Optional[re.Match[str]] = regex.match(period_string)
+        matcher: re.Match[str] | None = regex.match(period_string)
         if matcher:
             period = match_fn(matcher)
             if period is not None:
@@ -3415,7 +3414,7 @@ def _of(period_string: str) -> Period:
     Returns:
         A Period object
     """
-    period: Optional[Period] = _get_period(period_string)
+    period: Period | None = _get_period(period_string)
     if period is None:
         raise ValueError(f"Illegal period: {period_string}")
     return period
@@ -3433,7 +3432,7 @@ def _of_iso_duration(iso_8601_duration: str) -> Period:
         ValueError if the string contains a valid ISO 8601
         duration that cannot be converted into a Period object
     """
-    matcher: Optional[re.Match[str]] = _RE_PERIOD.match(iso_8601_duration)
+    matcher: re.Match[str] | None = _RE_PERIOD.match(iso_8601_duration)
     if matcher:
         return _match_period(matcher)
     raise ValueError(f"Illegal ISO 8601 duration: {iso_8601_duration}")
@@ -3453,7 +3452,7 @@ def _of_duration(duration: str) -> Period:
         ValueError if duration does not contains a valid duration
         string
     """
-    matcher: Optional[re.Match[str]] = _RE_PERIOD_OFFSET.match(duration)
+    matcher: re.Match[str] | None = _RE_PERIOD_OFFSET.match(duration)
     if matcher:
         return _match_period_offset(matcher)
     matcher = _RE_PERIOD.match(duration)
@@ -3475,7 +3474,7 @@ def _of_date_and_duration(date_duration: str) -> Period:
     Raises:
         ValueError if date_duration does not contains a valid value
     """
-    matcher: Optional[re.Match[str]] = _RE_DATETIME_PERIOD.match(date_duration)
+    matcher: re.Match[str] | None = _RE_DATETIME_PERIOD.match(date_duration)
     if matcher:
         return _match_datetime_period(matcher)
     raise ValueError(f"Illegal date/duration string: {date_duration}")
@@ -3490,7 +3489,7 @@ def _of_repr(repr_string: str) -> Period:
     Raises:
         ValueError if the string does not contain a valid repr string
     """
-    matcher: Optional[re.Match[str]] = _RE_REPR.match(repr_string)
+    matcher: re.Match[str] | None = _RE_REPR.match(repr_string)
     if matcher:
         return _match_repr(matcher)
     raise ValueError(f"Illegal repr string: {repr_string}")

--- a/src/time_stream/qc.py
+++ b/src/time_stream/qc.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time
-from typing import List, Optional, Tuple, Type, Union
+from typing import Type
 
 import polars as pl
 
@@ -55,7 +55,7 @@ class QCCheck(ABC):
         pass
 
     @classmethod
-    def get(cls, check: Union[str, "QCCheck", Type["QCCheck"]], **kwargs) -> "QCCheck":
+    def get(cls, check: "str | QCCheck | Type[QCCheck]", **kwargs) -> "QCCheck":
         """Factory method to get a QC check instance from string names or class type.
 
         Args:
@@ -108,7 +108,7 @@ class QCCheck(ABC):
         self,
         ts: TimeSeries,
         check_column: str,
-        observation_interval: Optional[datetime | Tuple[datetime, datetime | None]] = None,
+        observation_interval: datetime | tuple[datetime, datetime | None] | None = None,
     ) -> pl.Series:
         """Apply the QC check to the TimeSeries.
 
@@ -149,7 +149,7 @@ class ComparisonCheck(QCCheck):
 
     name = "comparison"
 
-    def __init__(self, compare_to: float | List, operator: str, flag_na: Optional[bool] = False) -> None:
+    def __init__(self, compare_to: float | list, operator: str, flag_na: bool = False) -> None:
         """Initialize comparison check.
 
         Args:
@@ -193,8 +193,8 @@ class RangeCheck(QCCheck):
         self,
         min_value: float | time | date | datetime,
         max_value: float | time | date | datetime,
-        closed: Optional[str | ClosedInterval] = "both",
-        within: Optional[bool] = True,
+        closed: str | ClosedInterval = "both",
+        within: bool = True,
     ) -> None:
         """Initialize range check.
 

--- a/src/time_stream/utils.py
+++ b/src/time_stream/utils.py
@@ -1,12 +1,11 @@
 from datetime import datetime
-from typing import Tuple
 
 import polars as pl
 
 from time_stream import Period
 
 
-def get_date_filter(time_name: str, observation_interval: datetime | Tuple[datetime, datetime | None]) -> pl.Expr:
+def get_date_filter(time_name: str, observation_interval: datetime | tuple[datetime, datetime | None]) -> pl.Expr:
     """Get Polars expression for observation date interval filtering.
 
     Args:

--- a/tests/time_stream/test_aggregation.py
+++ b/tests/time_stream/test_aggregation.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import datetime
-from typing import Dict, List, Union, Type
+from typing import Type
 from unittest.mock import Mock
 
 import polars as pl
@@ -47,14 +47,14 @@ def generate_time_series(resolution: Period, periodicity: Period, length: int, m
 
 
 def generate_expected_df(
-        timestamps: List[datetime],
+        timestamps: list[datetime],
         aggregator: Type[AggregationFunction],
-        columns: Union[str, List[str]],
-        values: Dict[str, List[Union[float, int]]],
-        expected_counts: List[int],
-        actual_counts: List[int],
-        timestamps_of: List[datetime]=None,
-        valid: Dict[str, List[bool]]=None
+        columns: str | list[str],
+        values: dict[str, list[float | int]],
+        expected_counts: list[int],
+        actual_counts: list[int],
+        timestamps_of: list[datetime]=None,
+        valid: dict[str, list[bool]]=None
 ) -> pl.DataFrame:
     """Helper function to create a dataframe of expected results from an aggregation test.
 

--- a/tests/time_stream/test_period.py
+++ b/tests/time_stream/test_period.py
@@ -16,8 +16,7 @@ import zoneinfo
 
 from typing import (
     Any,
-    Callable,
-    Optional,
+    Callable
 )
 from unittest.mock import patch, Mock
 from parameterized import parameterized
@@ -2949,7 +2948,7 @@ class TestPeriodTimedelta(unittest.TestCase):
     def test_is_valid(self, text: Any) -> None:
         """Test Period.timedelta property is valid for a set of Period instances"""
         period: Period = Period.of(text)
-        delta: Optional[datetime.timedelta] = period.timedelta
+        delta: datetime.timedelta = period.timedelta
         if delta is None:
             self.assertEqual(period._properties.step, p._STEP_MONTHS)
         else:
@@ -5379,10 +5378,10 @@ class TestPeriodWithTzinfo(unittest.TestCase):
             ("P1D", [TZ_UTC, None]),
         ]
     )
-    def test_offset_durations(self, name: Any, tz_info_list: list[Optional[datetime.tzinfo]]) -> None:
+    def test_offset_durations(self, name: Any, tz_info_list: list[datetime.tzinfo | None]) -> None:
         """Test Period.with_microsecond_offset method"""
         period: Period = Period.of_duration(name)
-        old_tz: datetime.tzinfo = None
+        old_tz: datetime.tzinfo | None = None
         for new_tz in tz_info_list:
             self.assertEqual(period.tzinfo, old_tz)
             period = period.with_tzinfo(new_tz)
@@ -6878,7 +6877,7 @@ class TestDateMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         dt: datetime.date = p._date_match(prefix, matcher)
         self.assertEqual(dt, d)
@@ -6891,7 +6890,7 @@ class TestTimeMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         tm: datetime.date = p._time_match(prefix, matcher)
         self.assertEqual(tm, t)
@@ -6913,7 +6912,7 @@ class TestTimezone(unittest.TestCase):
             ("-01:30", datetime.timezone(datetime.timedelta(hours=-1, minutes=-30))),
         ]
     )
-    def test_good(self, text: Any, tz: Optional[datetime.tzinfo]) -> None:
+    def test_good(self, text: Any, tz: datetime.tzinfo | None) -> None:
         self.assertEqual(tz, p._timezone(text))
 
 
@@ -6924,7 +6923,7 @@ class TestTzinfoMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         tz: datetime.date = p._tzinfo_match(prefix, matcher)
         self.assertEqual(tz, t.tzinfo)
@@ -6937,7 +6936,7 @@ class TestDatetimeMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         dt: datetime.date = p._datetime_match(prefix, matcher)
         answer: datetime.datetime = datetime.datetime.combine(date=d, time=t)
@@ -6961,7 +6960,7 @@ class TestMatchPeriod(unittest.TestCase):
     )
     def test_good(self, text: Any, iso: str) -> None:
         regex = re.compile(p._period_regex("period"))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_period(matcher)
         self.assertEqual(period, Period.of_iso_duration(iso))
@@ -6985,7 +6984,7 @@ class TestMatchPeriodOffset(unittest.TestCase):
     )
     def test_good(self, text: Any, duration: str) -> None:
         regex = re.compile(p._period_regex("period") + " -- " + p._period_regex("offset"))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_period_offset(matcher)
         self.assertEqual(period, Period.of_duration(duration))
@@ -7028,7 +7027,7 @@ class TestMatchDatetimePeriod(unittest.TestCase):
     )
     def test_good(self, text: Any, match_period: Period) -> None:
         regex = re.compile(p._datetime_regex("d") + r" -- " + p._period_regex("period"))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_datetime_period(matcher)
         self.assertEqual(period, match_period)
@@ -7078,7 +7077,7 @@ class TestMatchRepr(unittest.TestCase):
         ]
     )
     def test_good(self, text: Any, match_period: Period) -> None:
-        matcher: Optional[re.Match[str]] = _REPR_REGEX.match(text)
+        matcher: re.Match[str] | None = _REPR_REGEX.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_repr(matcher)
         self.assertEqual(period, match_period)
@@ -7086,7 +7085,7 @@ class TestMatchRepr(unittest.TestCase):
         ordinal: int = period.ordinal(shift_date)
         origin_date: datetime.datetime = period.datetime(ordinal)
         shift_amount: int = 0 - ordinal
-        matcher2: Optional[re.Match[str]] = _REPR_REGEX.match(f"{text}{shift_amount}")
+        matcher2: re.Match[str] | None = _REPR_REGEX.match(f"{text}{shift_amount}")
         self.assertNotEqual(matcher2, None)
         shifted_period: Period = p._match_repr(matcher2)
         ordinal2: int = shifted_period.ordinal(origin_date)


### PR DESCRIPTION
Refactored the module’s type hints for consistency and most recent best practices, including:

- Replaced legacy `typing.List`, `typing.Tuple`, etc. with built-in `list`, `tuple`, etc (https://peps.python.org/pep-0585/).
- Replaced `Union` with the more concise `|` operator for union types (https://peps.python.org/pep-0604/).
- Replaced `Optional[T]` with `T | None` for optional types (https://peps.python.org/pep-0604/).
- Ensured all forward references inside union annotations are wrapped as complete quoted strings to avoid parsing errors (see note here: https://docs.python.org/3/library/stdtypes.html#union-type).
