### PR TITLE
FPM-529 : Improve exceptions and error messages

### DIFF
--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -579,7 +579,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
     def aggregate(
         self,
         aggregation_period: Period,
-        aggregation_function: str | Type["AggregationFunction"] | AggregationFunction,
+        aggregation_function: "str | Type[AggregationFunction] | AggregationFunction",
         columns: str | list[str],
         missing_criteria: tuple[str, float | int] | None = None,
     ) -> "TimeSeries":
@@ -604,7 +604,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def qc_check(
         self,
-        check: str | Type["QCCheck"] | QCCheck,
+        check: "str | Type[QCCheck] | QCCheck",
         check_column: str,
         observation_interval: tuple[datetime, datetime | None] | None = None,
         **kwargs,
@@ -642,7 +642,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def infill(
         self,
-        infill_method: str | Type["InfillMethod"] | InfillMethod,
+        infill_method: "str | Type[InfillMethod] | InfillMethod",
         column: str,
         observation_interval: tuple[datetime, datetime | None] | None = None,
         max_gap_size: int | None = None,

--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -1,7 +1,7 @@
 from collections import Counter
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Type
 
 import polars as pl
 
@@ -25,15 +25,15 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         self,
         df: pl.DataFrame,
         time_name: str,
-        resolution: Optional[Period | str] = None,
-        periodicity: Optional[Period | str] = None,
-        supplementary_columns: Optional[list] = None,
-        flag_systems: Optional[Union[Dict[str, dict], Dict[str, Type[Enum]]]] = None,
-        flag_columns: Optional[Dict[str, str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        column_metadata: Optional[Dict[str, Dict[str, Any]]] = None,
-        on_duplicates: Optional[Union[DuplicateOption, str]] = DuplicateOption.ERROR,
-        pad: Optional[bool] = False,
+        resolution: Period | str | None = None,
+        periodicity: Period | str | None = None,
+        supplementary_columns: list | None = None,
+        flag_systems: dict[str, dict] | dict[str, Type[Enum]] | None = None,
+        flag_columns: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        column_metadata: dict[str, dict[str, Any]] | None = None,
+        on_duplicates: DuplicateOption | str = DuplicateOption.ERROR,
+        pad: bool = False,
     ) -> None:
         """Initialise a TimeSeries instance.
 
@@ -67,7 +67,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def _setup(
         self,
-        supplementary_columns: List[str],
+        supplementary_columns: list[str],
         flag_columns: dict[str, str],
         column_metadata: dict[str, dict[str, Any]],
         metadata: dict[str, Any],
@@ -104,7 +104,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def _setup_columns(
         self,
-        supplementary_columns: List[str] = None,
+        supplementary_columns: list[str] = None,
         flag_columns: dict[str, str] = None,
         column_metadata: dict[str, dict[str, Any]] = None,
     ) -> None:
@@ -492,7 +492,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         columns = {col.name: col for col in self._columns.values() if type(col) is not PrimaryTimeColumn}
         return columns
 
-    def select(self, col_names: List[str]) -> "TimeSeries":
+    def select(self, col_names: list[str]) -> "TimeSeries":
         """Filter TimeSeries instance to include only the specified columns.
 
         Args:
@@ -534,8 +534,8 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
     def init_supplementary_column(
         self,
         col_name: str,
-        data: Optional[Union[int, float, str, Iterable]] = None,
-        dtype: Optional[pl.DataType] = None,
+        data: int | float | str | Iterable | None = None,
+        dtype: pl.DataType | None = None,
     ) -> None:
         """Add a new column to the TimeSeries DataFrame, marking it as a supplementary column.
 
@@ -564,7 +564,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         supplementary_col = SupplementaryColumn(col_name, self)
         self._columns[col_name] = supplementary_col
 
-    def set_supplementary_column(self, col_name: Union[str, List[str]]) -> None:
+    def set_supplementary_column(self, col_name: str | list[str]) -> None:
         """Mark the specified existing column(s) as a supplementary column.
 
         Args:
@@ -579,9 +579,9 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
     def aggregate(
         self,
         aggregation_period: Period,
-        aggregation_function: Union[str, Type["AggregationFunction"], "AggregationFunction"],
-        columns: Union[str, List[str]],
-        missing_criteria: Optional[Tuple[str, Union[float, int]]] = None,
+        aggregation_function: str | Type["AggregationFunction"] | AggregationFunction,
+        columns: str | list[str],
+        missing_criteria: tuple[str, float | int] | None = None,
     ) -> "TimeSeries":
         """Apply an aggregation function to a column in this TimeSeries, check the aggregation satisfies user
         requirements and return a new derived TimeSeries containing the aggregated data.
@@ -604,9 +604,9 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def qc_check(
         self,
-        check: Union[str, "QCCheck", Type["QCCheck"]],
+        check: str | Type["QCCheck"] | QCCheck,
         check_column: str,
-        observation_interval: Optional[Tuple[datetime, Optional[datetime]]] = None,
+        observation_interval: tuple[datetime, datetime | None] | None = None,
         **kwargs,
     ) -> pl.Series:
         """Apply a quality control check to the TimeSeries.
@@ -642,10 +642,10 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
     def infill(
         self,
-        infill_method: Union[str, Type["InfillMethod"], "InfillMethod"],
+        infill_method: str | Type["InfillMethod"] | InfillMethod,
         column: str,
-        observation_interval: Optional[Tuple[datetime, Optional[datetime]]] = None,
-        max_gap_size: Optional[int] = None,
+        observation_interval: tuple[datetime, datetime | None] | None = None,
+        max_gap_size: int | None = None,
         **kwargs,
     ) -> "TimeSeries":
         """Apply an infilling method to a column in the TimeSeries to fill in missing data.
@@ -668,7 +668,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         infill_instance = InfillMethod.get(infill_method, **kwargs)
         return infill_instance.apply(self, column, observation_interval, max_gap_size)
 
-    def metadata(self, key: Optional[Sequence[str]] = None, strict: bool = True) -> Dict[str, Any]:
+    def metadata(self, key: str | list[str] | None = None, strict: bool = True) -> dict[str, Any]:
         """Retrieve metadata for all or specific keys.
 
         Args:
@@ -695,8 +695,8 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         return result
 
     def column_metadata(
-        self, column: Optional[Union[str, Sequence[str]]] = None, key: Optional[Union[str, Sequence[str]]] = None
-    ) -> Dict[str, Dict[str, Any]]:
+        self, column: str | list[str] | None = None, key: str | list[str] | None = None
+    ) -> dict[str, dict[str, Any]]:
         """Retrieve metadata for a given column(s), for all or specific keys.
 
         Args:
@@ -731,7 +731,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
 
         return result
 
-    def add_column_relationship(self, primary: str, other: Union[str, List[str]]) -> None:
+    def add_column_relationship(self, primary: str, other: str | list[str]) -> None:
         """Adds a relationship between the primary column and other column(s).
 
         Args:
@@ -744,7 +744,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         primary = self.columns[primary]
         primary.add_relationship(other)
 
-    def remove_column_relationship(self, primary: str, other: Union[str, List[str]]) -> None:
+    def remove_column_relationship(self, primary: str, other: str | list[str]) -> None:
         """Removes a relationship between the primary column and other column(s).
 
         Args:
@@ -758,9 +758,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         for other_column in other:
             primary.remove_relationship(other_column)
 
-    def get_flag_system_column(
-        self, data_column: Union[str, TimeSeriesColumn], flag_system: str
-    ) -> Optional["TimeSeriesColumn"]:
+    def get_flag_system_column(self, data_column: str | TimeSeriesColumn, flag_system: str) -> TimeSeriesColumn | None:
         """Retrieves the flag system column corresponding to the given data column and flag system.
 
         Args:
@@ -837,7 +835,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
         except (KeyError, AttributeError):
             raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
-    def __getitem__(self, key: Union[str, List[str], tuple[str]]) -> Union["TimeSeries", PrimaryTimeColumn]:
+    def __getitem__(self, key: str | Iterable[str]) -> "TimeSeries | PrimaryTimeColumn":
         """Access columns or the time column using indexing syntax.
 
         This method enables convenient access to DataFrame columns or the time column by using indexing. It supports:
@@ -897,7 +895,7 @@ class TimeSeries:  # noqa: PLW1641 ignore hash warning
             f"flag_columns={list(self.flag_columns.keys())}, "
         )
 
-    def __dir__(self) -> List[str]:
+    def __dir__(self) -> list[str]:
         """Return a list of attributes associated with the TimeSeries class.
 
         This method extends the default attributes of the TimeSeries class by including the column names of the

--- a/src/time_stream/bitwise.py
+++ b/src/time_stream/bitwise.py
@@ -1,5 +1,4 @@
 from enum import EnumType, Flag
-from typing import Union
 
 
 class BitwiseMeta(EnumType):
@@ -68,7 +67,7 @@ class BitwiseFlag(int, Flag, metaclass=BitwiseMeta):
             raise ValueError(f"Flag is not unique: {value}")
 
     @classmethod
-    def get_single_flag(cls, flag: Union[int, str]) -> "BitwiseFlag":
+    def get_single_flag(cls, flag: int | str) -> "BitwiseFlag":
         """Retrieves a single flag from an integer or string value.
 
         Can't be a combination of integer flag values, for example with the classification of:

--- a/src/time_stream/columns.py
+++ b/src/time_stream/columns.py
@@ -1,6 +1,6 @@
 import copy
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Sequence, Type
 
 import polars as pl
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
     """Base class for all column types in a TimeSeries."""
 
-    def __init__(self, name: str, ts: "TimeSeries", metadata: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, name: str, ts: "TimeSeries", metadata: dict[str, Any] | None = None) -> None:
         """Initializes a TimeSeriesColumn instance.
 
         Args:
@@ -49,7 +49,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         if self.name not in self._ts.df.columns:
             raise ValueError(f"Column '{self.name}' not found in TimeSeries.")
 
-    def metadata(self, key: Optional[Sequence[str]] = None, strict: bool = True) -> Dict[str, Any]:
+    def metadata(self, key: Sequence[str] = None, strict: bool = True) -> dict[str, Any]:
         """Retrieve metadata for all or specific keys.
 
         Args:
@@ -75,7 +75,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
             result[k] = value
         return result
 
-    def remove_metadata(self, key: Optional[Union[str, list[str], tuple[str, ...]]] = None) -> None:
+    def remove_metadata(self, key: str | list[str] | tuple[str, ...] | None = None) -> None:
         """Removes metadata associated with a column, either completely or for specific keys.
 
         Args:
@@ -91,8 +91,8 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
 
     def _set_as(
         self,
-        column_type: "Type[TimeSeriesColumn]",
-        related_columns: Optional[Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]] = None,
+        column_type: Type["TimeSeriesColumn"],
+        related_columns: "str | TimeSeriesColumn | list[TimeSeriesColumn | str] | None" = None,
         *args,
         **kwargs,
     ) -> "TimeSeriesColumn":
@@ -124,7 +124,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         return column
 
     def set_as_supplementary(
-        self, related_columns: Optional[Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]] = None
+        self, related_columns: "str | TimeSeriesColumn | list[TimeSeriesColumn | str] | None" = None
     ) -> "TimeSeriesColumn":
         """Converts the column to a SupplementaryColumn while preserving metadata.
 
@@ -142,7 +142,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
     def set_as_flag(
         self,
         flag_system: str,
-        related_columns: Optional[Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]] = None,
+        related_columns: "str | TimeSeriesColumn | list[TimeSeriesColumn | str] | None" = None,
     ) -> "TimeSeriesColumn":
         """Converts the column to a FlagColumn while preserving metadata.
 
@@ -235,7 +235,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         return self._ts.select([self.name])
 
     @abstractmethod
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Defines relationships between columns.
 
         Args:
@@ -243,7 +243,7 @@ class TimeSeriesColumn(ABC):  # noqa: PLW1641 ignore hash warning
         """
         pass
 
-    def remove_relationship(self, other: Union["TimeSeriesColumn", str]) -> None:
+    def remove_relationship(self, other: "TimeSeriesColumn | str") -> None:
         """Remove relationships between columns.
 
         Args:
@@ -404,7 +404,7 @@ class PrimaryTimeColumn(TimeSeriesColumn):
 class DataColumn(TimeSeriesColumn):
     """Represents primary data columns."""
 
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Adds a relationship between this data column and supplementary or flag column(s).
 
         Args:
@@ -428,7 +428,7 @@ class DataColumn(TimeSeriesColumn):
 
             self._ts._relationship_manager._add(relationship)
 
-    def get_flag_system_column(self, flag_system: str) -> Optional["TimeSeriesColumn"]:
+    def get_flag_system_column(self, flag_system: str) -> "TimeSeriesColumn | None":
         """Retrieves the flag column linked to this data column that corresponds to the specified flag system.
 
         Args:
@@ -459,7 +459,7 @@ class DataColumn(TimeSeriesColumn):
 class SupplementaryColumn(TimeSeriesColumn):
     """Represents supplementary columns (e.g., metadata, extra information)."""
 
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Adds a relationship between this supplementary column and data column(s).
 
         Args:
@@ -489,9 +489,7 @@ class FlagColumn(SupplementaryColumn):
     or other categorical flags. Flags are stored using bitwise operations for efficiency.
     """
 
-    def __init__(
-        self, name: str, ts: "TimeSeries", flag_system: str, metadata: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def __init__(self, name: str, ts: "TimeSeries", flag_system: str, metadata: dict[str, Any] | None = None) -> None:
         """
         Initializes a FlagColumn.
 
@@ -504,7 +502,7 @@ class FlagColumn(SupplementaryColumn):
         super().__init__(name, ts, metadata)
         self.flag_system = self._ts.flag_systems[flag_system]
 
-    def add_relationship(self, other: Union["TimeSeriesColumn", str, list[Union["TimeSeriesColumn", str]]]) -> None:
+    def add_relationship(self, other: "str | TimeSeriesColumn | list[TimeSeriesColumn | str]") -> None:
         """Adds a relationship between this flag column and data column(s).
 
         Args:
@@ -526,7 +524,7 @@ class FlagColumn(SupplementaryColumn):
 
             self._ts._relationship_manager._add(relationship)
 
-    def add_flag(self, flag: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def add_flag(self, flag: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """Adds a flag value to this FlagColumn using a bitwise OR operation.
 
         Args:
@@ -539,7 +537,7 @@ class FlagColumn(SupplementaryColumn):
             pl.when(expr).then(pl.col(self.name) | flag.value).otherwise(pl.col(self.name))
         )
 
-    def remove_flag(self, flag: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def remove_flag(self, flag: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """Remove a flag value from this FlagColumn using a bitwise AND operation.
 
         Args:

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -62,3 +62,23 @@ class TimeMutatedError(TimeStreamError):
         self.old_timestamps = old_timestamps
         self.new_timestamps = new_timestamps
         super().__init__(msg)
+
+
+class AggregationError(TimeStreamError):
+    """Base class for aggregation-related errors"""
+
+
+class UnknownAggregationError(AggregationError):
+    """Raised when an unknown aggregation is requested."""
+
+
+class AggregationTypeError(AggregationError):
+    """Raised when an invalid aggregation type is provided."""
+
+
+class AggregationPeriodError(AggregationError):
+    """Raised when an aggregation period is invalid."""
+
+
+class MissingCriteriaError(AggregationError):
+    """Raised when invalid or inconsistent missing data criteria are provided."""

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -88,17 +88,33 @@ class BitwiseFlagError(TimeStreamError):
     """Base class for BitwiseFlag-related errors."""
 
 
-class BitwiseFlagTypeError(BitwiseFlagError, TypeError):
+class BitwiseFlagTypeError(BitwiseFlagError):
     """Raised when a flag value has the wrong type."""
 
 
-class BitwiseFlagValueError(BitwiseFlagError, ValueError):
+class BitwiseFlagValueError(BitwiseFlagError):
     """Raised when a flag value is invalid (negative, not power of two, or zero)."""
 
 
-class BitwiseFlagDuplicateError(BitwiseFlagError, ValueError):
+class BitwiseFlagDuplicateError(BitwiseFlagError):
     """Raised when a flag value is not unique within the enumeration."""
 
 
-class BitwiseFlagUnknownError(BitwiseFlagError, KeyError):
+class BitwiseFlagUnknownError(BitwiseFlagError):
     """Raised when a flag lookup fails or a non-singular flag is requested."""
+
+
+class InfillError(TimeStreamError):
+    """Base class for infill-related errors"""
+
+
+class UnknownInfillError(InfillError):
+    """Raised when an unknown infill method is requested."""
+
+
+class InfillTypeError(InfillError):
+    """Raised when an invalid infill method type is provided."""
+
+
+class InfillInsufficientValuesError(InfillError):
+    """Raised when there are insufficient number of values to carry out the infill method."""

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -152,7 +152,7 @@ class PeriodParsingError(PeriodError):
     """Raised when things like a period string or timedelta cannot be parsed."""
 
 
-class PeriodValidationError(PeriodError, ValueError):
+class PeriodValidationError(PeriodError):
     """Raised when a validation on objects in the Period module fails."""
 
 

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -138,3 +138,19 @@ class InfillTypeError(InfillError):
 
 class InfillInsufficientValuesError(InfillError):
     """Raised when there are insufficient number of values to carry out the infill method."""
+
+
+class PeriodError(Exception):
+    """Base exception for all period-related errors."""
+
+
+class PeriodConfigError(PeriodError):
+    """Raised when constructing or configuring objects within the Period module with unsupported options."""
+
+
+class PeriodParsingError(PeriodError):
+    """Raised when things like a period string or timedelta cannot be parsed."""
+
+
+class PeriodValidationError(PeriodError, ValueError):
+    """Raised when a validation on objects in the Period module fails."""

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -104,6 +104,22 @@ class BitwiseFlagUnknownError(BitwiseFlagError):
     """Raised when a flag lookup fails or a non-singular flag is requested."""
 
 
+class QcError(TimeStreamError):
+    """Base class for qc-related errors"""
+
+
+class UnknownQcError(QcError):
+    """Raised when an unknown QC method is requested."""
+
+
+class QcTypeError(QcError):
+    """Raised when an invalid QC method type is provided."""
+
+
+class QcUnknownOperatorError(QcError):
+    """Raised when an invalid operator is passed to a QC check."""
+
+
 class InfillError(TimeStreamError):
     """Base class for infill-related errors"""
 

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -1,3 +1,8 @@
+from collections.abc import Iterable
+
+from time_stream.enums import DuplicateOption
+
+
 class TimeStreamError(Exception):
     """Base class for custom errors in the time-stream package."""
 
@@ -17,6 +22,19 @@ class DuplicateColumnError(TimeStreamError):
 class DuplicateTimeError(TimeStreamError):
     """Raised when duplicate time values are found."""
 
+    def __init__(
+        self,
+        msg: str | None = None,
+        duplicates: Iterable | None = None,
+    ):
+        if not msg:
+            msg = (
+                f"Duplicate time values found. A TimeSeries must have unique time values. "
+                f"Options for dealing with duplicate rows include: {[o.name for o in DuplicateOption]}."
+            )
+        self.duplicates = duplicates
+        super().__init__(msg)
+
 
 class MetadataError(TimeStreamError):
     """Raised when there is an error with the metadata within time series object."""
@@ -32,3 +50,15 @@ class ResolutionError(TimeStreamError):
 
 class TimeMutatedError(TimeStreamError):
     """Raised when the time values have been detected as being mutated."""
+
+    def __init__(
+        self, msg: str | None = None, old_timestamps: Iterable | None = None, new_timestamps: Iterable | None = None
+    ):
+        if not msg:
+            msg = (
+                "Time column has been modified. Adding, removing or modifying time rows requires creating a new "
+                "TimeSeries instance."
+            )
+        self.old_timestamps = old_timestamps
+        self.new_timestamps = new_timestamps
+        super().__init__(msg)

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -15,6 +15,10 @@ class ColumnTypeError(TimeStreamError):
     """Raised when a requested column is not the expected type."""
 
 
+class ColumnRelationshipError(TimeStreamError):
+    """Raised when there is an issue with the relationship of one column to another"""
+
+
 class DuplicateColumnError(TimeStreamError):
     """Raised when a column name is duplicated."""
 

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -82,3 +82,23 @@ class AggregationPeriodError(AggregationError):
 
 class MissingCriteriaError(AggregationError):
     """Raised when invalid or inconsistent missing data criteria are provided."""
+
+
+class BitwiseFlagError(TimeStreamError):
+    """Base class for BitwiseFlag-related errors."""
+
+
+class BitwiseFlagTypeError(BitwiseFlagError, TypeError):
+    """Raised when a flag value has the wrong type."""
+
+
+class BitwiseFlagValueError(BitwiseFlagError, ValueError):
+    """Raised when a flag value is invalid (negative, not power of two, or zero)."""
+
+
+class BitwiseFlagDuplicateError(BitwiseFlagError, ValueError):
+    """Raised when a flag value is not unique within the enumeration."""
+
+
+class BitwiseFlagUnknownError(BitwiseFlagError, KeyError):
+    """Raised when a flag lookup fails or a non-singular flag is requested."""

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -154,3 +154,19 @@ class PeriodParsingError(PeriodError):
 
 class PeriodValidationError(PeriodError, ValueError):
     """Raised when a validation on objects in the Period module fails."""
+
+
+class FlagSystemError(TimeStreamError):
+    """Base class for flag-system related errors."""
+
+
+class DuplicateFlagSystemError(FlagSystemError):
+    """Raised when a flag system already exists."""
+
+
+class FlagSystemTypeError(FlagSystemError):
+    """Raised when an invalid flag system type is provided."""
+
+
+class FlagSystemNotFoundError(FlagSystemError):
+    """Raised when a flag system can't be found."""

--- a/src/time_stream/exceptions.py
+++ b/src/time_stream/exceptions.py
@@ -1,0 +1,34 @@
+class TimeStreamError(Exception):
+    """Base class for custom errors in the time-stream package."""
+
+
+class ColumnNotFoundError(TimeStreamError):
+    """Raised when a requested column does not exist."""
+
+
+class ColumnTypeError(TimeStreamError):
+    """Raised when a requested column is not the expected type."""
+
+
+class DuplicateColumnError(TimeStreamError):
+    """Raised when a column name is duplicated."""
+
+
+class DuplicateTimeError(TimeStreamError):
+    """Raised when duplicate time values are found."""
+
+
+class MetadataError(TimeStreamError):
+    """Raised when there is an error with the metadata within time series object."""
+
+
+class PeriodicityError(TimeStreamError):
+    """Raised when datetime values do not conform to the specified periodicity."""
+
+
+class ResolutionError(TimeStreamError):
+    """Raised when datetime values are not aligned to the specified resolution."""
+
+
+class TimeMutatedError(TimeStreamError):
+    """Raised when the time values have been detected as being mutated."""

--- a/src/time_stream/flag_manager.py
+++ b/src/time_stream/flag_manager.py
@@ -1,5 +1,5 @@
 import enum
-from typing import TYPE_CHECKING, Sequence, Type, Union
+from typing import TYPE_CHECKING, Sequence, Type
 
 import polars as pl
 
@@ -28,7 +28,7 @@ class TimeSeriesFlagManager:
     def flag_systems(self) -> dict[str, Type[enum.Enum]]:
         return self._flag_systems
 
-    def _setup_flag_systems(self, flag_systems: dict[str, Union[dict[str, int], Type[enum.Enum]]] = None) -> None:
+    def _setup_flag_systems(self, flag_systems: dict[str, dict[str, int] | Type[enum.Enum]] | None = None) -> None:
         """Adds flag systems into the flag manager.
 
         Args:
@@ -38,7 +38,7 @@ class TimeSeriesFlagManager:
         for name, flag_system in flag_systems.items():
             self.add_flag_system(name, flag_system)
 
-    def add_flag_system(self, name: str, flag_system: Union[dict[str, int], Type[enum.Enum]]) -> None:
+    def add_flag_system(self, name: str, flag_system: dict[str, dict[str, int] | Type[enum.Enum]]) -> None:
         """Adds a flag system to the flag manager, which contains flag values and their meanings.
 
         A flag system can be used to create flag columns that are specific to a particular type of flag.
@@ -75,7 +75,7 @@ class TimeSeriesFlagManager:
         else:
             raise TypeError(f"Unknown type of flag system: {type(flag_system)}")
 
-    def init_flag_column(self, flag_system: str, col_name: str, data: Union[int, Sequence[int]] = 0) -> None:
+    def init_flag_column(self, flag_system: str, col_name: str, data: int | Sequence[int] = 0) -> None:
         """Add a new column to the TimeSeries DataFrame, setting it as a Flag Column.
 
         Args:
@@ -102,7 +102,7 @@ class TimeSeriesFlagManager:
         flag_col = FlagColumn(col_name, self._ts, flag_system)
         self._ts._columns[col_name] = flag_col
 
-    def set_flag_column(self, flag_system: str, col_name: Union[str, list[str]]) -> None:
+    def set_flag_column(self, flag_system: str, col_name: str | list[str]) -> None:
         """Mark the specified existing column(s) as a flag column.
 
         Args:
@@ -115,7 +115,7 @@ class TimeSeriesFlagManager:
         for col in col_name:
             self._ts.columns[col].set_as_flag(flag_system)
 
-    def add_flag(self, col_name: str, flag_value: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def add_flag(self, col_name: str, flag_value: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """Add flag value (if not there) to flag column, where expression is True.
 
         Args:
@@ -125,7 +125,7 @@ class TimeSeriesFlagManager:
         """
         self._ts.columns[col_name].add_flag(flag_value, expr)
 
-    def remove_flag(self, col_name: str, flag_value: Union[int, str], expr: pl.Expr = pl.lit(True)) -> None:
+    def remove_flag(self, col_name: str, flag_value: int | str, expr: pl.Expr = pl.lit(True)) -> None:
         """
         Remove flag value (if there) from flag column.
 

--- a/src/time_stream/infill.py
+++ b/src/time_stream/infill.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, Type
 
 import numpy as np
 import polars as pl
@@ -61,7 +61,7 @@ class InfillMethod(ABC):
         pass
 
     @classmethod
-    def get(cls, method: Union[str, Type["InfillMethod"]], **kwargs) -> "InfillMethod":
+    def get(cls, method: str | Type["InfillMethod"], **kwargs) -> "InfillMethod":
         """Factory method to get an infill method class instance from string names or class type.
 
         Args:
@@ -106,8 +106,8 @@ class InfillMethod(ABC):
         df: pl.DataFrame,
         time_name: str,
         infill_column: str,
-        observation_interval: Optional[datetime | Tuple[datetime, datetime | None]] = None,
-        max_gap_size: Optional[int] = None,
+        observation_interval: datetime | tuple[datetime, datetime | None] | None = None,
+        max_gap_size: int | None = None,
     ) -> bool:
         """Check if there is actually anything to infill in the provided dataframe, considering the maximum gap size
         and datetime observation interval constraints
@@ -142,8 +142,8 @@ class InfillMethod(ABC):
         self,
         ts: TimeSeries,
         infill_column: str,
-        observation_interval: Optional[datetime | Tuple[datetime, datetime | None]] = None,
-        max_gap_size: Optional[int] = None,
+        observation_interval: datetime | tuple[datetime, datetime | None] | None = None,
+        max_gap_size: int | None = None,
     ) -> "TimeSeries":
         """Apply the infill method to the TimeSeries.
 

--- a/src/time_stream/infill.py
+++ b/src/time_stream/infill.py
@@ -7,7 +7,8 @@ import polars as pl
 from scipy.interpolate import Akima1DInterpolator, PchipInterpolator, make_interp_spline
 
 from time_stream import TimeSeries
-from time_stream.utils import gap_size_count, get_date_filter, pad_time
+from time_stream.exceptions import InfillInsufficientValuesError, InfillTypeError, UnknownInfillError
+from time_stream.utils import check_columns_in_dataframe, gap_size_count, get_date_filter, pad_time
 
 # Registry for built-in infill methods
 _INFILL_REGISTRY = {}
@@ -88,17 +89,21 @@ class InfillMethod(ABC):
             try:
                 return _INFILL_REGISTRY[method](**kwargs)
             except KeyError:
-                raise KeyError(f"Unknown infill method '{method}'.")
+                raise UnknownInfillError(
+                    f"Unknown infill method '{method}'. Available methods: {list(_INFILL_REGISTRY.keys())}"
+                )
 
         # If it's a class, check the subclass type and return
         elif isinstance(method, type):
             if issubclass(method, InfillMethod):
                 return method(**kwargs)  # type: ignore[misc]
             else:
-                raise TypeError(f"Infill method class {method.__name__} must inherit from InfillMethod")
+                raise InfillTypeError(f"Infill method class '{method.__name__}' must inherit from InfillMethod.")
 
         else:
-            raise TypeError(f"Infill method must be a string or an InfillMethod class. Got {type(method).__name__}")
+            raise InfillTypeError(
+                f"Infill method must be a string or an InfillMethod class. Got {type(method).__name__}"
+            )
 
     @classmethod
     def infill_mask(
@@ -167,7 +172,7 @@ class InfillMethod(ABC):
         """
         # Validate column exists
         if infill_column not in ts.columns:
-            raise KeyError(f"Infill column '{infill_column}' not found in TimeSeries.")
+            raise check_columns_in_dataframe(f"Infill column '{infill_column}' not found in TimeSeries.")
 
         # Set the timeseries property
         self._ts = ts
@@ -284,8 +289,8 @@ class ScipyInterpolation(InfillMethod, ABC):
 
         # Check if we have enough points
         if n_valid < self.min_points_required:
-            raise ValueError(
-                f"{self.name} requires at least {self.min_points_required} data points, "
+            raise InfillInsufficientValuesError(
+                f"Infill method '{self.name}' requires at least {self.min_points_required} data points, "
                 f"but only {n_valid} valid points found."
             )
 

--- a/src/time_stream/infill.py
+++ b/src/time_stream/infill.py
@@ -7,8 +7,13 @@ import polars as pl
 from scipy.interpolate import Akima1DInterpolator, PchipInterpolator, make_interp_spline
 
 from time_stream import TimeSeries
-from time_stream.exceptions import InfillInsufficientValuesError, InfillTypeError, UnknownInfillError
-from time_stream.utils import check_columns_in_dataframe, gap_size_count, get_date_filter, pad_time
+from time_stream.exceptions import (
+    ColumnNotFoundError,
+    InfillInsufficientValuesError,
+    InfillTypeError,
+    UnknownInfillError,
+)
+from time_stream.utils import gap_size_count, get_date_filter, pad_time
 
 # Registry for built-in infill methods
 _INFILL_REGISTRY = {}
@@ -102,7 +107,7 @@ class InfillMethod(ABC):
 
         else:
             raise InfillTypeError(
-                f"Infill method must be a string or an InfillMethod class. Got {type(method).__name__}"
+                f"Infill method must be a string or an InfillMethod class. Got '{type(method).__name__}'"
             )
 
     @classmethod
@@ -172,7 +177,7 @@ class InfillMethod(ABC):
         """
         # Validate column exists
         if infill_column not in ts.columns:
-            raise check_columns_in_dataframe(f"Infill column '{infill_column}' not found in TimeSeries.")
+            raise ColumnNotFoundError(f"Infill column '{infill_column}' not found in TimeSeries.")
 
         # Set the timeseries property
         self._ts = ts

--- a/src/time_stream/period.py
+++ b/src/time_stream/period.py
@@ -2598,22 +2598,23 @@ class YearPeriod(Period):
 
         if properties.multiplier != 12:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be '12' for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. Must be '12' for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
     @override
@@ -2639,22 +2640,23 @@ class MultiYearPeriod(Period):
         if properties.multiplier <= 12 or (properties.multiplier % 12) != 0:
             raise PeriodValidationError(
                 f"Illegal multiplier: {properties.multiplier}. "
-                f"Must be a >12 and multiple of 12 for a '{self.__name__}'."
+                f"Must be a >12 and multiple of 12 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         self._n = properties.multiplier // 12
@@ -2681,22 +2683,23 @@ class MonthPeriod(Period):
 
         if properties.multiplier != 1:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a 1 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. Must be a 1 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
     @override
@@ -2723,22 +2726,23 @@ class MultiMonthPeriod(Period):
 
         if properties.multiplier <= 1:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a >1 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. Must be a >1 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         self._n = properties.multiplier
@@ -2766,26 +2770,29 @@ class NaiveDayPeriod(Period):
 
         if properties.multiplier != 86_400:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a 86_400 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. Must be a 86_400 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: "
+                f"{properties.microsecond_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.tzinfo is not None:
-            raise PeriodValidationError(f"Illegal tzinfo: '{properties.tzinfo}'. Must be None for a '{self.__name__}'.")
+            raise PeriodValidationError(
+                f"Illegal tzinfo: '{properties.tzinfo}'. Must be None for a '{self.__class__.__name__}'."
+            )
 
     @override
     def ordinal(self, datetime_obj: dt.datetime) -> int:
@@ -2809,27 +2816,28 @@ class AwareDayPeriod(Period):
 
         if properties.multiplier != 86_400:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a 86_400 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. Must be a 86_400 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: "
+                f"{properties.microsecond_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if not isinstance(properties.tzinfo, dt.tzinfo):
             raise PeriodValidationError(
-                f"Illegal tzinfo: '{properties.tzinfo}'. Must be of type tzinfo for a '{self.__name__}'."
+                f"Illegal tzinfo: '{properties.tzinfo}'. Must be of type tzinfo for a '{self.__class__.__name__}'."
             )
 
     @override
@@ -2854,26 +2862,30 @@ class NaiveMultiDayPeriod(Period):
 
         if properties.multiplier < 86_400 or (properties.multiplier % 86_400) != 0:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 86_400 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. "
+                f"Must be a multiple of 86_400 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.tzinfo is not None:
-            raise PeriodValidationError(f"Illegal tzinfo: '{properties.tzinfo}'. Must be None for a '{self.__name__}'.")
+            raise PeriodValidationError(
+                f"Illegal tzinfo: '{properties.tzinfo}'. Must be None for a '{self.__class__.__name__}'."
+            )
 
         self._n = properties.multiplier // 86_400
 
@@ -2899,27 +2911,29 @@ class AwareMultiDayPeriod(Period):
 
         if properties.multiplier < 86_400 or (properties.multiplier % 86_400) != 0:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 86_400 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. "
+                f"Must be a multiple of 86_400 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if not isinstance(properties.tzinfo, dt.tzinfo):
             raise PeriodValidationError(
-                f"Illegal tzinfo: '{properties.tzinfo}'. Must be of type tzinfo for a '{self.__name__}'."
+                f"Illegal tzinfo: '{properties.tzinfo}'. Must be of type tzinfo for a '{self.__class__.__name__}'."
             )
 
         self._n = properties.multiplier // 86_400
@@ -2946,22 +2960,24 @@ class MultiHourPeriod(Period):
 
         if properties.multiplier < 3_600 or (properties.multiplier % 3_600) != 0:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 3_600 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. "
+                f"Must be a multiple of 3_600 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         self._n = properties.multiplier // 3_600
@@ -2989,26 +3005,30 @@ class NaiveMultiMinutePeriod(Period):
 
         if properties.multiplier < 60 or (properties.multiplier % 60) != 0:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 60 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. "
+                f"Must be a multiple of 60 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.tzinfo is not None:
-            raise PeriodValidationError(f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__name__}'.")
+            raise PeriodValidationError(
+                f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__class__.__name__}'."
+            )
 
         self._n = properties.multiplier // 60
 
@@ -3035,27 +3055,29 @@ class AwareMultiMinutePeriod(Period):
 
         if properties.multiplier < 60 or (properties.multiplier % 60) != 0:
             raise PeriodValidationError(
-                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 60 for a '{self.__name__}'."
+                f"Illegal multiplier: {properties.multiplier}. "
+                f"Must be a multiple of 60 for a '{self.__class__.__name__}'."
             )
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if not isinstance(properties.tzinfo, dt.tzinfo):
             raise PeriodValidationError(
-                f"Illegal tzinfo: {properties.tzinfo}. Must of type tzinfo for a '{self.__name__}'."
+                f"Illegal tzinfo: {properties.tzinfo}. Must of type tzinfo for a '{self.__class__.__name__}'."
             )
 
         self._n = properties.multiplier // 60
@@ -3083,21 +3105,24 @@ class NaiveMultiSecondPeriod(Period):
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.tzinfo is not None:
-            raise PeriodValidationError(f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__name__}'.")
+            raise PeriodValidationError(
+                f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__class__.__name__}'."
+            )
 
         self._n = properties.multiplier
 
@@ -3122,22 +3147,23 @@ class AwareMultiSecondPeriod(Period):
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if not isinstance(properties.tzinfo, dt.tzinfo):
             raise PeriodValidationError(
-                f"Illegal tzinfo: {properties.tzinfo}. Must be of type tzinfo for a '{self.__name__}'."
+                f"Illegal tzinfo: {properties.tzinfo}. Must be of type tzinfo for a '{self.__class__.__name__}'."
             )
 
         self._n = properties.multiplier
@@ -3165,21 +3191,24 @@ class NaiveMicroSecondPeriod(Period):
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.tzinfo is not None:
-            raise PeriodValidationError(f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__name__}'.")
+            raise PeriodValidationError(
+                f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__class__.__name__}'."
+            )
 
         self._n = properties.multiplier
 
@@ -3209,22 +3238,23 @@ class AwareMicroSecondPeriod(Period):
 
         if properties.month_offset != 0:
             raise PeriodValidationError(
-                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.microsecond_offset != 0:
             raise PeriodValidationError(
-                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+                f"Illegal microsecond offset: {properties.microsecond_offset}. "
+                f"Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if properties.ordinal_shift != 0:
             raise PeriodValidationError(
-                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__class__.__name__}'."
             )
 
         if not isinstance(properties.tzinfo, dt.tzinfo):
             raise PeriodValidationError(
-                f"Illegal tzinfo: {properties.tzinfo}. Must be of type tzinfo for a '{self.__name__}'."
+                f"Illegal tzinfo: {properties.tzinfo}. Must be of type tzinfo for a '{self.__class__.__name__}'."
             )
 
         self._n = properties.multiplier

--- a/src/time_stream/period.py
+++ b/src/time_stream/period.py
@@ -59,7 +59,6 @@ from dataclasses import (
 )
 from typing import (
     Any,
-    Optional,
     override,
 )
 
@@ -185,7 +184,7 @@ class DateTimeAdjusters:
     advance: Callable[[dt.datetime], dt.datetime]
 
     @staticmethod
-    def of_month_offset(month_offset: int) -> Optional["DateTimeAdjusters"]:
+    def of_month_offset(month_offset: int) -> "DateTimeAdjusters | None":
         """Return a DateTimeAdjusters object for a given month offset,
         or return None if the month offset is 0
 
@@ -210,7 +209,7 @@ class DateTimeAdjusters:
         )
 
     @staticmethod
-    def of_microsecond_offset(microsecond_offset: int) -> Optional["DateTimeAdjusters"]:
+    def of_microsecond_offset(microsecond_offset: int) -> "DateTimeAdjusters | None":
         """Return a DateTimeAdjusters object for a given microsecond offset,
         or return None if the microsecond offset is 0
 
@@ -544,7 +543,7 @@ def _fmt_tzdelta(delta: dt.timedelta) -> str:
     return f"{sign}{hours:02}:{minutes:02}"
 
 
-def _fmt_tzinfo(tz: Optional[dt.tzinfo]) -> str:
+def _fmt_tzinfo(tz: dt.tzinfo | None) -> str:
     """Convert an optional tzinfo object into a string that
     can be used to represent the timezone in an ISO 8601 format
 
@@ -688,7 +687,7 @@ class Properties:
     multiplier: int
     month_offset: int
     microsecond_offset: int
-    tzinfo: Optional[dt.tzinfo]
+    tzinfo: dt.tzinfo | None
     ordinal_shift: int
 
     @staticmethod
@@ -948,7 +947,7 @@ class Properties:
             ordinal_shift=0,
         ).normalise_offsets()
 
-    def with_tzinfo(self, tzinfo: Optional[dt.tzinfo]) -> "Properties":
+    def with_tzinfo(self, tzinfo: dt.tzinfo | None) -> "Properties":
         """Return a Properties object derived from this one with
         the given datetime tzinfo object (time zone)
 
@@ -1036,7 +1035,7 @@ class Properties:
             return _get_month_period_name(self.multiplier)
         raise AssertionError(f"Illegal step: {self.step}")
 
-    def get_timedelta(self) -> Optional[dt.timedelta]:
+    def get_timedelta(self) -> dt.timedelta | None:
         """Return a timedelta object that matches the duration
         of this period, or None if no such timedelta exists
 
@@ -1609,7 +1608,7 @@ class PeriodFields:
         return self.get_months_seconds().get_base_properties()
 
 
-def _str2int(num: Optional[str], default: int = 0) -> int:
+def _str2int(num: str | None, default: int = 0) -> int:
     """Convert string to int, None becomes 0 (or default if specified)
 
     Args:
@@ -1625,7 +1624,7 @@ def _str2int(num: Optional[str], default: int = 0) -> int:
     return default if num is None else int(num)
 
 
-def _str2microseconds(num: Optional[str], default: int = 0) -> int:
+def _str2microseconds(num: str | None, default: int = 0) -> int:
     """Convert string to microseconds, None becomes 0 (or default if specified)
 
     A seconds + microseconds string looks like "nn.uuu". This function
@@ -1918,7 +1917,7 @@ class Period(ABC):
         return self._properties.get_iso8601()
 
     @property
-    def tzinfo(self) -> Optional[dt.tzinfo]:
+    def tzinfo(self) -> dt.tzinfo | None:
         """Get the tzinfo property"""
         return self._properties.tzinfo
 
@@ -1959,7 +1958,7 @@ class Period(ABC):
         return self.ordinal(dt.datetime.max)
 
     @property
-    def timedelta(self) -> Optional[dt.timedelta]:
+    def timedelta(self) -> dt.timedelta | None:
         """A timedelta object that matches the duration
         of this period, or None if no such timedelta exists
 
@@ -2291,7 +2290,7 @@ class Period(ABC):
         """
         return _get_offset_period(self._properties.with_microsecond_offset(microsecond_amount))
 
-    def with_tzinfo(self, tzinfo: Optional[dt.tzinfo]) -> "Period":
+    def with_tzinfo(self, tzinfo: dt.tzinfo | None) -> "Period":
         """Return a Period derived from this one but with the
         specified tzinfo
 
@@ -2911,7 +2910,7 @@ class AwareMicroSecondPeriod(Period):
 
 
 def _get_period_tzinfo(
-    tzinfo: Optional[dt.tzinfo],
+    tzinfo: dt.tzinfo | None,
     properties: Properties,
     naive: Callable[[Properties], Period],
     aware: Callable[[Properties], Period],
@@ -3157,7 +3156,7 @@ def _time_match(prefix: str, matcher: re.Match[str]) -> dt.time:
     )
 
 
-def _timezone(utc_offset: Optional[str]) -> Optional[dt.tzinfo]:
+def _timezone(utc_offset: str | None) -> dt.tzinfo | None:
     """Convert an optional string into an optional tzinfo
     object
 
@@ -3183,7 +3182,7 @@ def _timezone(utc_offset: Optional[str]) -> Optional[dt.tzinfo]:
     return dt.timezone(dt.timedelta(seconds=seconds))
 
 
-def _tzinfo_match(prefix: str, matcher: re.Match[str]) -> Optional[dt.tzinfo]:
+def _tzinfo_match(prefix: str, matcher: re.Match[str]) -> dt.tzinfo | None:
     """Extract a tzinfo object out of a regular expression matcher that
     has parsed an ISO 8601 format datetime
 
@@ -3295,11 +3294,11 @@ def _match_repr(matcher: re.Match[str]) -> Period:
     """
     period_fields: PeriodFields = _period_match("period", matcher)
     offset: str = matcher.group("offset")
-    offset_period_fields: Optional[PeriodFields] = None
+    offset_period_fields: PeriodFields | None = None
     if offset == "+":
         offset_period_fields = _period_match("offset", matcher)
     zone: str = matcher.group("zone")
-    tzinfo: Optional[dt.tzinfo] = None
+    tzinfo: dt.tzinfo | None = None
     if zone is not None and len(zone) > 0:
         tzinfo = _timezone(zone)
     shift: str = matcher.group("shift")
@@ -3375,7 +3374,7 @@ _RE_REPR = re.compile(
 #            object created from the Pattern into an optional
 #            Period object.
 #
-_PARSERS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Optional[Period]]]] = [
+_PARSERS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Period | None]]] = [
     (_RE_PERIOD, _match_period),
     (_RE_PERIOD_OFFSET, _match_period_offset),
     (_RE_DATETIME_PERIOD, _match_datetime_period),
@@ -3383,7 +3382,7 @@ _PARSERS: list[tuple[re.Pattern[str], Callable[[re.Match[str]], Optional[Period]
 ]
 
 
-def _get_period(period_string: str) -> Optional[Period]:
+def _get_period(period_string: str) -> Period | None:
     """Return an optional Period object from a string
 
     Tries a number of possible string formats and returns
@@ -3395,9 +3394,9 @@ def _get_period(period_string: str) -> Optional[Period]:
         not be converted to a Period
     """
     regex: re.Pattern[str]
-    match_fn: Callable[[re.Match[str]], Optional[Period]]
+    match_fn: Callable[[re.Match[str]], Period | None]
     for regex, match_fn in _PARSERS:
-        matcher: Optional[re.Match[str]] = regex.match(period_string)
+        matcher: re.Match[str] | None = regex.match(period_string)
         if matcher:
             period = match_fn(matcher)
             if period is not None:
@@ -3415,7 +3414,7 @@ def _of(period_string: str) -> Period:
     Returns:
         A Period object
     """
-    period: Optional[Period] = _get_period(period_string)
+    period: Period | None = _get_period(period_string)
     if period is None:
         raise ValueError(f"Illegal period: {period_string}")
     return period
@@ -3433,7 +3432,7 @@ def _of_iso_duration(iso_8601_duration: str) -> Period:
         ValueError if the string contains a valid ISO 8601
         duration that cannot be converted into a Period object
     """
-    matcher: Optional[re.Match[str]] = _RE_PERIOD.match(iso_8601_duration)
+    matcher: re.Match[str] | None = _RE_PERIOD.match(iso_8601_duration)
     if matcher:
         return _match_period(matcher)
     raise ValueError(f"Illegal ISO 8601 duration: {iso_8601_duration}")
@@ -3453,7 +3452,7 @@ def _of_duration(duration: str) -> Period:
         ValueError if duration does not contains a valid duration
         string
     """
-    matcher: Optional[re.Match[str]] = _RE_PERIOD_OFFSET.match(duration)
+    matcher: re.Match[str] | None = _RE_PERIOD_OFFSET.match(duration)
     if matcher:
         return _match_period_offset(matcher)
     matcher = _RE_PERIOD.match(duration)
@@ -3475,7 +3474,7 @@ def _of_date_and_duration(date_duration: str) -> Period:
     Raises:
         ValueError if date_duration does not contains a valid value
     """
-    matcher: Optional[re.Match[str]] = _RE_DATETIME_PERIOD.match(date_duration)
+    matcher: re.Match[str] | None = _RE_DATETIME_PERIOD.match(date_duration)
     if matcher:
         return _match_datetime_period(matcher)
     raise ValueError(f"Illegal date/duration string: {date_duration}")
@@ -3490,7 +3489,7 @@ def _of_repr(repr_string: str) -> Period:
     Raises:
         ValueError if the string does not contain a valid repr string
     """
-    matcher: Optional[re.Match[str]] = _RE_REPR.match(repr_string)
+    matcher: re.Match[str] | None = _RE_REPR.match(repr_string)
     if matcher:
         return _match_repr(matcher)
     raise ValueError(f"Illegal repr string: {repr_string}")

--- a/src/time_stream/period.py
+++ b/src/time_stream/period.py
@@ -62,6 +62,8 @@ from typing import (
     override,
 )
 
+from time_stream.exceptions import PeriodConfigError, PeriodParsingError, PeriodValidationError
+
 
 def _naive(datetime_obj: dt.datetime) -> dt.datetime:
     """Return a datetime object without a tzinfo
@@ -249,7 +251,7 @@ class DateTimeAdjusters:
         if (month_adjusters is not None) and (microsecond_adjusters is None):
             return month_adjusters
         if (month_adjusters is None) or (microsecond_adjusters is None):
-            raise AssertionError()
+            raise PeriodConfigError("At least one of 'month_offset' or 'microsecond_offset' must have a value.")
         m_retreat = month_adjusters.retreat
         m_advance = month_adjusters.advance
         s_retreat = microsecond_adjusters.retreat
@@ -272,7 +274,7 @@ class DateTimeAdjusters:
 
     def __post_init__(self) -> None:
         if (self.retreat is None) or (self.advance is None):
-            raise AssertionError()
+            raise PeriodConfigError("At least one of 'retreat' or 'advance' must have a value.")
 
 
 # ------------------------------------------------------------------------------
@@ -521,15 +523,13 @@ def _fmt_naive_year(obj: dt.datetime) -> str:
 
 
 def _fmt_tzdelta(delta: dt.timedelta) -> str:
-    """Convert a timedelta which represents a timezone
-    to a string that respresents that timezone
+    """Convert a timedelta which represents a timezone to a string that represents that timezone
 
     Args:
         delta: The timedelta
 
     Returns:
-        A string that can be used to represent a timezone
-        in an ISO 8601 format string
+        A string that can be used to represent a timezone in an ISO 8601 format string
     """
     seconds = int(delta.total_seconds())
     if seconds == 0:
@@ -537,7 +537,7 @@ def _fmt_tzdelta(delta: dt.timedelta) -> str:
     sign = "-" if seconds < 0 else "+"
     days, seconds_in_day = divmod(abs(seconds), 86_400)
     if days > 0:
-        raise ValueError(f"Illegal tz delta: {delta}")
+        raise PeriodParsingError(f"Illegal tz delta: {delta}. Amount of time must be less than 1 day.")
     hours, seconds_in_hour = divmod(seconds_in_day, 3_600)
     minutes = seconds_in_hour // 60
     return f"{sign}{hours:02}:{minutes:02}"
@@ -813,15 +813,24 @@ class Properties:
 
     def __post_init__(self) -> None:
         if self.step not in _VALID_STEPS:
-            raise AssertionError(f"Illegal step: {self.step}")
+            raise PeriodValidationError(f"Illegal step: '{self.step}'. Must be one of: {_VALID_STEPS}")
+
         if self.multiplier <= 0:
-            raise AssertionError(f"Illegal multiplier: {self.multiplier}")
+            raise PeriodValidationError(f"Illegal multiplier: {self.multiplier}. Must be greater than zero.")
+
         if self.month_offset < 0:
-            raise AssertionError(f"Illegal month offset: {self.month_offset}")
+            raise PeriodValidationError(f"Illegal month offset: {self.month_offset}. Must be zero or greater.")
+
         if self.microsecond_offset < 0:
-            raise AssertionError(f"Illegal microsecond offset: {self.microsecond_offset}")
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {self.microsecond_offset}. Must be zero or greater."
+            )
+
         if (self.step != _STEP_MONTHS) and (self.month_offset != 0):
-            raise AssertionError("Illegal month offset for non-month step")
+            raise PeriodValidationError(
+                f"Illegal month offset '{self.month_offset}' for non-month step '{self.step}'. "
+                f"Month offset must be zero.'"
+            )
 
     def normalise_step_and_multiplier(self) -> "Properties":
         """Return an equivalent Properties object where
@@ -876,14 +885,25 @@ class Properties:
         new_microsecond_offset: int = self.microsecond_offset
         if self.step == _STEP_MONTHS:
             new_month_offset = self.month_offset % self.multiplier
+
         elif self.step == _STEP_SECONDS:
-            assert self.month_offset == 0
+            if self.month_offset != 0:
+                raise PeriodValidationError(
+                    f"Illegal month offset '{self.month_offset}' for non-month step '{self.step}'. "
+                    f"Month offset must be zero.'"
+                )
             new_microsecond_offset = self.microsecond_offset % (self.multiplier * 1_000_000)
+
         elif self.step == _STEP_MICROSECONDS:
-            assert self.month_offset == 0
+            if self.month_offset != 0:
+                raise PeriodValidationError(
+                    f"Illegal month offset '{self.month_offset}' for non-month step '{self.step}'. "
+                    f"Month offset must be zero.'"
+                )
             new_microsecond_offset = self.microsecond_offset % self.multiplier
+
         else:
-            raise AssertionError(f"Illegal step: {self.step}")
+            raise PeriodValidationError(f"Illegal step: '{self.step}'. Must be one of: {_VALID_STEPS}")
 
         if (
             (new_month_offset == self.month_offset)
@@ -1033,7 +1053,8 @@ class Properties:
             return _get_second_period_name(self.multiplier)
         if self.step == _STEP_MONTHS:
             return _get_month_period_name(self.multiplier)
-        raise AssertionError(f"Illegal step: {self.step}")
+
+        raise PeriodValidationError(f"Illegal step: '{self.step}'. Must be one of: {_VALID_STEPS}")
 
     def get_timedelta(self) -> dt.timedelta | None:
         """Return a timedelta object that matches the duration
@@ -1052,7 +1073,8 @@ class Properties:
             return dt.timedelta(seconds=self.multiplier)
         if self.step == _STEP_MONTHS:
             return None
-        raise AssertionError(f"Illegal step: {self.step}")
+
+        raise PeriodValidationError(f"Illegal step: '{self.step}'. Must be one of: {_VALID_STEPS}")
 
     def _append_step_elems(self, elems: list[str]) -> None:
         """Add elements to a list of string that describe the
@@ -1069,7 +1091,7 @@ class Properties:
         elif self.step == _STEP_MONTHS:
             _append_month_elems(elems, self.multiplier)
         else:
-            raise AssertionError(f"Illegal step: {self.step}")
+            raise PeriodValidationError(f"Illegal step: '{self.step}'. Must be one of: {_VALID_STEPS}")
 
     def _append_offset_elems(self, elems: list[str]) -> None:
         """Add elements to a list of string that describe the
@@ -1164,7 +1186,11 @@ class Properties:
         if o_total_days > 0:
             return _fmt_naive_day
 
-        assert self.step == _STEP_MONTHS
+        if self.step != _STEP_MONTHS:
+            raise PeriodConfigError(
+                f"Error retrieving datetime formatter function. Invalid step: '{self.step}' for the period."
+            )
+
         o_months_nn = self.month_offset % 12
         s_months_nn = self.multiplier % 12
         # Check if months need to be output
@@ -1221,7 +1247,11 @@ class Properties:
         if o_hours_nn != 0:
             return lambda dt: _fmt_aware_hour(dt, separator)
 
-        assert self.step == _STEP_MONTHS
+        if self.step != _STEP_MONTHS:
+            raise PeriodConfigError(
+                f"Error retrieving datetime formatter function. Invalid step: '{self.step}' for the period."
+            )
+
         return lambda dt: _fmt_aware_hour(dt, separator)
 
     def pl_interval(self) -> str:
@@ -1246,7 +1276,7 @@ class Properties:
         elif self.step == _STEP_MONTHS:
             return f"{self.multiplier}mo"
         else:
-            raise AssertionError(f"Illegal step: {self.step}")
+            raise PeriodValidationError(f"Illegal step: '{self.step}'. Must be one of: {_VALID_STEPS}")
 
     def pl_offset(self) -> str:
         """Return a string that captures the month and microsecond
@@ -1300,7 +1330,7 @@ class Properties:
             num_per_year: int = 12 // self.multiplier
             return (self.multiplier * num_per_year) == 12
         else:
-            raise AssertionError(f"Illegal step: {self.step}")
+            raise PeriodValidationError(f"Illegal step: '{self.step}'. Must be one of: {_VALID_STEPS}")
 
     def count(self, other: "Properties") -> int:
         """
@@ -1470,7 +1500,7 @@ class Properties:
                     return _COUNT_UNALIGNED
                 return mult_q
 
-        raise AssertionError(f"Unhandled step combination: {self.step}/{other.step}")
+        raise PeriodConfigError(f"Unhandled step combination: {self.step}/{other.step}")
 
     def __str__(self) -> str:
         elems: list[str] = ["P"]
@@ -1503,9 +1533,9 @@ class MonthsSeconds:
 
     def __post_init__(self) -> None:
         if (self.months < 0) or (self.seconds < 0) or (self.microseconds < 0) or (self.microseconds > 999_999):
-            raise ValueError(f"Illegal period: {self.string}")
+            raise PeriodValidationError(f"Illegal period: {self.string}")
         if (self.months == 0) and (self.seconds == 0) and (self.microseconds == 0):
-            raise ValueError(f"Illegal period: {self.string}")
+            raise PeriodValidationError(f"Illegal period: {self.string}")
 
     def get_step_and_multiplier(self) -> tuple[int, int]:
         """Return a tuple of two integers containing the
@@ -1525,7 +1555,7 @@ class MonthsSeconds:
             return _STEP_SECONDS, self.seconds
         if (self.months == 0) and (self.microseconds > 0):
             return _STEP_MICROSECONDS, self.total_microseconds()
-        raise ValueError(f"Illegal period: {self.string}")
+        raise PeriodValidationError(f"Illegal period: {self.string}")
 
     def total_microseconds(self) -> int:
         """Return total microseconds from the seconds
@@ -1582,7 +1612,7 @@ class PeriodFields:
             or (self.microseconds < 0)
             or (self.microseconds > 999_999)
         ):
-            raise ValueError(f"Illegal period: {self.string}")
+            raise PeriodValidationError(f"Illegal period: {self.string}")
 
     def get_months_seconds(self) -> MonthsSeconds:
         """Return a MonthsSeconds object from the fields
@@ -1898,17 +1928,32 @@ class Period(ABC):
 
     def __init__(self, properties: Properties) -> None:
         if properties is None:
-            raise ValueError()
-        assert isinstance(properties.step, int)
-        assert properties.step in _VALID_STEPS
-        assert isinstance(properties.multiplier, int)
-        assert properties.multiplier > 0
-        assert isinstance(properties.month_offset, int)
-        assert properties.month_offset >= 0
-        assert isinstance(properties.microsecond_offset, int)
-        assert properties.microsecond_offset >= 0
-        assert isinstance(properties.tzinfo, (dt.tzinfo, type(None)))
-        assert isinstance(properties.ordinal_shift, int)
+            raise PeriodConfigError("No properties object provided.")
+
+        if properties.step not in _VALID_STEPS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be one of: {_VALID_STEPS}")
+
+        if properties.multiplier <= 0 or not isinstance(properties.multiplier, int):
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be an integer greater than zero."
+            )
+
+        if properties.month_offset < 0 or not isinstance(properties.multiplier, int):
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be an integer zero or greater."
+            )
+
+        if properties.microsecond_offset < 0 or not isinstance(properties.multiplier, int):
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be an integer zero or greater."
+            )
+
+        if not isinstance(properties.tzinfo, (dt.tzinfo, type(None))):
+            raise PeriodValidationError(f"Illegal tzinfo: {properties.tzinfo}. Must be of type dt.tzinfo or None.")
+
+        if not isinstance(properties.ordinal_shift, int):
+            raise PeriodValidationError(f"Illegal ordinal shift: {properties.ordinal_shift}. Must be of type integer.")
+
         self._properties = properties
 
     @property
@@ -2040,7 +2085,7 @@ class Period(ABC):
             returns a string
         """
         if separator not in (" ", "T", "t"):
-            raise ValueError(f"Illegal separator: {separator}")
+            raise PeriodParsingError(f"Illegal separator: {separator}. Must be one of {(' ', 'T', 't')}")
         return self._properties.get_naive_formatter(separator)
 
     def aware_formatter(self, separator: str = "T") -> Callable[[dt.datetime], str]:
@@ -2056,7 +2101,7 @@ class Period(ABC):
             returns a string
         """
         if separator not in (" ", "T", "t"):
-            raise ValueError(f"Illegal separator: {separator}")
+            raise PeriodParsingError(f"Illegal separator: {separator}. Must be one of {(' ', 'T', 't')}")
         return self._properties.get_aware_formatter(separator)
 
     def formatter(self, separator: str = "T") -> Callable[[dt.datetime], str]:
@@ -2072,7 +2117,7 @@ class Period(ABC):
             returns a string
         """
         if separator not in (" ", "T", "t"):
-            raise ValueError(f"Illegal separator: {separator}")
+            raise PeriodParsingError(f"Illegal separator: {separator}. Must be one of {(' ', 'T', 't')}")
         return self.naive_formatter(separator) if self._properties.tzinfo is None else self.aware_formatter(separator)
 
     @abstractmethod
@@ -2547,11 +2592,29 @@ class YearPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_MONTHS
-        assert properties.multiplier == 12
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_MONTHS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_MONTHS}.")
+
+        if properties.multiplier != 12:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be '12' for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
 
     @override
     def ordinal(self, datetime_obj: dt.datetime) -> int:
@@ -2569,12 +2632,31 @@ class MultiYearPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_MONTHS
-        assert properties.multiplier > 12
-        assert (properties.multiplier % 12) == 0
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_MONTHS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_MONTHS}.")
+
+        if properties.multiplier <= 12 or (properties.multiplier % 12) != 0:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. "
+                f"Must be a >12 and multiple of 12 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
         self._n = properties.multiplier // 12
 
     @override
@@ -2593,11 +2675,29 @@ class MonthPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_MONTHS
-        assert properties.multiplier == 1
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_MONTHS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_MONTHS}.")
+
+        if properties.multiplier != 1:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a 1 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
 
     @override
     def ordinal(self, datetime_obj: dt.datetime) -> int:
@@ -2617,11 +2717,30 @@ class MultiMonthPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_MONTHS
-        assert properties.multiplier > 1
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_MONTHS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_MONTHS}.")
+
+        if properties.multiplier <= 1:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a >1 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
         self._n = properties.multiplier
 
     @override
@@ -2641,12 +2760,32 @@ class NaiveDayPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.multiplier == 86_400
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.tzinfo is None
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.multiplier != 86_400:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a 86_400 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.tzinfo is not None:
+            raise PeriodValidationError(f"Illegal tzinfo: '{properties.tzinfo}'. Must be None for a '{self.__name__}'.")
 
     @override
     def ordinal(self, datetime_obj: dt.datetime) -> int:
@@ -2664,12 +2803,34 @@ class AwareDayPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.multiplier == 86_400
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert isinstance(properties.tzinfo, dt.tzinfo)
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.multiplier != 86_400:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a 86_400 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if not isinstance(properties.tzinfo, dt.tzinfo):
+            raise PeriodValidationError(
+                f"Illegal tzinfo: '{properties.tzinfo}'. Must be of type tzinfo for a '{self.__name__}'."
+            )
 
     @override
     def ordinal(self, datetime_obj: dt.datetime) -> int:
@@ -2687,13 +2848,33 @@ class NaiveMultiDayPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.multiplier >= 86_400
-        assert (properties.multiplier % 86_400) == 0
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.tzinfo is None
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.multiplier < 86_400 or (properties.multiplier % 86_400) != 0:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 86_400 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.tzinfo is not None:
+            raise PeriodValidationError(f"Illegal tzinfo: '{properties.tzinfo}'. Must be None for a '{self.__name__}'.")
+
         self._n = properties.multiplier // 86_400
 
     @override
@@ -2712,13 +2893,35 @@ class AwareMultiDayPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.multiplier >= 86_400
-        assert (properties.multiplier % 86_400) == 0
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert isinstance(properties.tzinfo, dt.tzinfo)
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.multiplier < 86_400 or (properties.multiplier % 86_400) != 0:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 86_400 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if not isinstance(properties.tzinfo, dt.tzinfo):
+            raise PeriodValidationError(
+                f"Illegal tzinfo: '{properties.tzinfo}'. Must be of type tzinfo for a '{self.__name__}'."
+            )
+
         self._n = properties.multiplier // 86_400
 
     @override
@@ -2737,12 +2940,30 @@ class MultiHourPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.multiplier >= 3_600
-        assert (properties.multiplier % 3_600) == 0
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.multiplier < 3_600 or (properties.multiplier % 3_600) != 0:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 3_600 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
         self._n = properties.multiplier // 3_600
 
     @override
@@ -2762,13 +2983,33 @@ class NaiveMultiMinutePeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.multiplier >= 60
-        assert (properties.multiplier % 60) == 0
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.tzinfo is None
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.multiplier < 60 or (properties.multiplier % 60) != 0:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 60 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.tzinfo is not None:
+            raise PeriodValidationError(f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__name__}'.")
+
         self._n = properties.multiplier // 60
 
     @override
@@ -2788,13 +3029,35 @@ class AwareMultiMinutePeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.multiplier >= 60
-        assert (properties.multiplier % 60) == 0
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert isinstance(properties.tzinfo, dt.tzinfo)
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.multiplier < 60 or (properties.multiplier % 60) != 0:
+            raise PeriodValidationError(
+                f"Illegal multiplier: {properties.multiplier}. Must be a multiple of 60 for a '{self.__name__}'."
+            )
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if not isinstance(properties.tzinfo, dt.tzinfo):
+            raise PeriodValidationError(
+                f"Illegal tzinfo: {properties.tzinfo}. Must of type tzinfo for a '{self.__name__}'."
+            )
+
         self._n = properties.multiplier // 60
 
     @override
@@ -2814,11 +3077,28 @@ class NaiveMultiSecondPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.tzinfo is None
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.tzinfo is not None:
+            raise PeriodValidationError(f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__name__}'.")
+
         self._n = properties.multiplier
 
     @override
@@ -2836,11 +3116,30 @@ class AwareMultiSecondPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_SECONDS
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert isinstance(properties.tzinfo, dt.tzinfo)
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_SECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_SECONDS}.")
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if not isinstance(properties.tzinfo, dt.tzinfo):
+            raise PeriodValidationError(
+                f"Illegal tzinfo: {properties.tzinfo}. Must be of type tzinfo for a '{self.__name__}'."
+            )
+
         self._n = properties.multiplier
 
     @override
@@ -2860,11 +3159,28 @@ class NaiveMicroSecondPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_MICROSECONDS
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert properties.tzinfo is None
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_MICROSECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_MICROSECONDS}.")
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.tzinfo is not None:
+            raise PeriodValidationError(f"Illegal tzinfo: {properties.tzinfo}. Must be None for a '{self.__name__}'.")
+
         self._n = properties.multiplier
 
     @override
@@ -2887,11 +3203,30 @@ class AwareMicroSecondPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.step == _STEP_MICROSECONDS
-        assert properties.month_offset == 0
-        assert properties.microsecond_offset == 0
-        assert isinstance(properties.tzinfo, dt.tzinfo)
-        assert properties.ordinal_shift == 0
+
+        if properties.step != _STEP_MICROSECONDS:
+            raise PeriodValidationError(f"Illegal step: '{properties.step}'. Must be: {_STEP_MICROSECONDS}.")
+
+        if properties.month_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal month offset: {properties.month_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.microsecond_offset != 0:
+            raise PeriodValidationError(
+                f"Illegal microsecond offset: {properties.microsecond_offset}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(
+                f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0' for a '{self.__name__}'."
+            )
+
+        if not isinstance(properties.tzinfo, dt.tzinfo):
+            raise PeriodValidationError(
+                f"Illegal tzinfo: {properties.tzinfo}. Must be of type tzinfo for a '{self.__name__}'."
+            )
+
         self._n = properties.multiplier
 
     @override
@@ -2938,7 +3273,9 @@ def _get_offset_period(properties: Properties) -> Period:
     Returns:
         A Period object
     """
-    assert properties.ordinal_shift == 0
+    if properties.ordinal_shift != 0:
+        raise PeriodValidationError(f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0'.")
+
     if (properties.month_offset != 0) or (properties.microsecond_offset != 0):
         return OffsetPeriod(properties)
     return _get_base_period(properties)
@@ -2960,8 +3297,12 @@ def _get_base_period(properties: Properties) -> Period:
     month_offset = properties.month_offset
     microsecond_offset = properties.microsecond_offset
     tzinfo = properties.tzinfo
-    assert month_offset == 0
-    assert microsecond_offset == 0
+
+    if month_offset != 0:
+        raise PeriodValidationError(f"Illegal month_offset: {month_offset}. Must be '0'.")
+
+    if microsecond_offset != 0:
+        raise PeriodValidationError(f"Illegal microsecond_offset: {microsecond_offset}. Must be '0'.")
 
     if step == _STEP_MONTHS:
         if multiplier == 1:
@@ -3002,7 +3343,7 @@ def _get_base_period(properties: Properties) -> Period:
     if step == _STEP_MICROSECONDS:
         return _get_period_tzinfo(tzinfo, properties, NaiveMicroSecondPeriod, AwareMicroSecondPeriod)
 
-    raise ValueError("Oops")
+    raise PeriodValidationError(f"Illegal step: '{step}'. Must be one of: {_VALID_STEPS}")
 
 
 class OffsetPeriod(Period):
@@ -3012,8 +3353,16 @@ class OffsetPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert (properties.month_offset > 0) or (properties.microsecond_offset > 0)
-        assert properties.ordinal_shift == 0
+
+        if not ((properties.month_offset > 0) or (properties.microsecond_offset > 0)):
+            raise PeriodValidationError(
+                f"No offset detected in month_offset or microsecond_offset: "
+                f"{properties.month_offset}/{properties.microsecond_offset}"
+            )
+
+        if properties.ordinal_shift != 0:
+            raise PeriodValidationError(f"Illegal ordinal shift: {properties.ordinal_shift}. Must be '0'.")
+
         date_time_adjusters = DateTimeAdjusters.of_offsets(properties.month_offset, properties.microsecond_offset)
         base_period = _get_base_period(
             Properties(
@@ -3052,7 +3401,10 @@ class ShiftedPeriod(Period):
 
     def __init__(self, properties: Properties) -> None:
         super().__init__(properties)
-        assert properties.ordinal_shift != 0
+
+        if properties.ordinal_shift == 0:
+            raise PeriodValidationError(f"Illegal ordinal shift: {properties.ordinal_shift}. Must not be '0'.")
+
         offset_period = _get_offset_period(
             Properties(
                 step=properties.step,
@@ -3124,11 +3476,14 @@ def _date_match(prefix: str, matcher: re.Match[str]) -> dt.date:
     Returns:
         A date object
     """
-    return dt.date(
-        year=int(matcher.group(f"{prefix}_yyyy")),
-        month=_str2int(matcher.group(f"{prefix}_mm"), 1),
-        day=_str2int(matcher.group(f"{prefix}_dd"), 1),
-    )
+    try:
+        return dt.date(
+            year=int(matcher.group(f"{prefix}_yyyy")),
+            month=_str2int(matcher.group(f"{prefix}_mm"), 1),
+            day=_str2int(matcher.group(f"{prefix}_dd"), 1),
+        )
+    except ValueError:
+        raise PeriodParsingError(f"Unable to parse date from {prefix}")
 
 
 def _time_match(prefix: str, matcher: re.Match[str]) -> dt.time:
@@ -3147,13 +3502,16 @@ def _time_match(prefix: str, matcher: re.Match[str]) -> dt.time:
     Returns:
         A time object
     """
-    return dt.time(
-        hour=_str2int(matcher.group(f"{prefix}_HH")),
-        minute=_str2int(matcher.group(f"{prefix}_MM")),
-        second=_str2int(matcher.group(f"{prefix}_SS")),
-        microsecond=_str2microseconds(matcher.group(f"{prefix}_MS")),
-        tzinfo=_tzinfo_match(prefix, matcher),
-    )
+    try:
+        return dt.time(
+            hour=_str2int(matcher.group(f"{prefix}_HH")),
+            minute=_str2int(matcher.group(f"{prefix}_MM")),
+            second=_str2int(matcher.group(f"{prefix}_SS")),
+            microsecond=_str2microseconds(matcher.group(f"{prefix}_MS")),
+            tzinfo=_tzinfo_match(prefix, matcher),
+        )
+    except ValueError:
+        raise PeriodParsingError(f"Unable to parse time from {prefix}.")
 
 
 def _timezone(utc_offset: str | None) -> dt.tzinfo | None:
@@ -3416,7 +3774,7 @@ def _of(period_string: str) -> Period:
     """
     period: Period | None = _get_period(period_string)
     if period is None:
-        raise ValueError(f"Illegal period: {period_string}")
+        raise PeriodParsingError(f"Illegal period: {period_string}")
     return period
 
 
@@ -3435,7 +3793,7 @@ def _of_iso_duration(iso_8601_duration: str) -> Period:
     matcher: re.Match[str] | None = _RE_PERIOD.match(iso_8601_duration)
     if matcher:
         return _match_period(matcher)
-    raise ValueError(f"Illegal ISO 8601 duration: {iso_8601_duration}")
+    raise PeriodParsingError(f"Illegal ISO 8601 duration: {iso_8601_duration}")
 
 
 def _of_duration(duration: str) -> Period:
@@ -3458,7 +3816,7 @@ def _of_duration(duration: str) -> Period:
     matcher = _RE_PERIOD.match(duration)
     if matcher:
         return _match_period(matcher)
-    raise ValueError(f"Illegal duration: {duration}")
+    raise PeriodParsingError(f"Illegal duration: {duration}")
 
 
 def _of_date_and_duration(date_duration: str) -> Period:
@@ -3472,12 +3830,12 @@ def _of_date_and_duration(date_duration: str) -> Period:
         A Period object
 
     Raises:
-        ValueError if date_duration does not contains a valid value
+        ValueError if date_duration does not contain a valid value
     """
     matcher: re.Match[str] | None = _RE_DATETIME_PERIOD.match(date_duration)
     if matcher:
         return _match_datetime_period(matcher)
-    raise ValueError(f"Illegal date/duration string: {date_duration}")
+    raise PeriodParsingError(f"Illegal date/duration string: {date_duration}")
 
 
 def _of_repr(repr_string: str) -> Period:
@@ -3492,4 +3850,4 @@ def _of_repr(repr_string: str) -> Period:
     matcher: re.Match[str] | None = _RE_REPR.match(repr_string)
     if matcher:
         return _match_repr(matcher)
-    raise ValueError(f"Illegal repr string: {repr_string}")
+    raise PeriodParsingError(f"Illegal repr string: {repr_string}")

--- a/src/time_stream/qc.py
+++ b/src/time_stream/qc.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import date, datetime, time
-from typing import List, Optional, Tuple, Type, Union
+from typing import Type
 
 import polars as pl
 
@@ -55,7 +55,7 @@ class QCCheck(ABC):
         pass
 
     @classmethod
-    def get(cls, check: Union[str, "QCCheck", Type["QCCheck"]], **kwargs) -> "QCCheck":
+    def get(cls, check: "str | QCCheck | Type[QCCheck]", **kwargs) -> "QCCheck":
         """Factory method to get a QC check instance from string names or class type.
 
         Args:
@@ -108,7 +108,7 @@ class QCCheck(ABC):
         self,
         ts: TimeSeries,
         check_column: str,
-        observation_interval: Optional[datetime | Tuple[datetime, datetime | None]] = None,
+        observation_interval: datetime | tuple[datetime, datetime | None] | None = None,
     ) -> pl.Series:
         """Apply the QC check to the TimeSeries.
 
@@ -149,7 +149,7 @@ class ComparisonCheck(QCCheck):
 
     name = "comparison"
 
-    def __init__(self, compare_to: float | List, operator: str, flag_na: Optional[bool] = False) -> None:
+    def __init__(self, compare_to: float | list, operator: str, flag_na: bool = False) -> None:
         """Initialize comparison check.
 
         Args:
@@ -193,8 +193,8 @@ class RangeCheck(QCCheck):
         self,
         min_value: float | time | date | datetime,
         max_value: float | time | date | datetime,
-        closed: Optional[str | ClosedInterval] = "both",
-        within: Optional[bool] = True,
+        closed: str | ClosedInterval = "both",
+        within: bool = True,
     ) -> None:
         """Initialize range check.
 

--- a/src/time_stream/relationships.py
+++ b/src/time_stream/relationships.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from time_stream.enums import DeletionPolicy, RelationshipType
+from time_stream.exceptions import ColumnRelationshipError
 
 if TYPE_CHECKING:
     # Import is for type hinting only.  Make sure there is no runtime import, to avoid recursion.
@@ -137,9 +138,9 @@ class RelationshipManager:
                             raise ValueError
 
                 except ValueError:
-                    raise ValueError(
-                        f"{col.name} can only be related to one column. "
-                        f"Existing relationships: {existing_relationships}"
+                    raise ColumnRelationshipError(
+                        f"'{col.name}' can only be related to one column. "
+                        f"Existing relationships: {existing_relationships}."
                     )
 
         __check(relationship.primary_column)
@@ -188,9 +189,9 @@ class RelationshipManager:
                 self._remove(relationship)
 
             elif relationship.deletion_policy.value == DeletionPolicy.RESTRICT.value:
-                raise UserWarning(
-                    f"Cannot delete {column} because it has restricted relationship "
-                    f"with: {relationship.other_column.name}"
+                raise ColumnRelationshipError(
+                    f"Cannot delete '{column}' because it has restricted relationship "
+                    f"with: '{relationship.other_column.name}'"
                 )
 
         self._relationships.pop(column.name, None)

--- a/src/time_stream/utils.py
+++ b/src/time_stream/utils.py
@@ -139,6 +139,6 @@ def check_columns_in_dataframe(df: pl.DataFrame, columns: Iterable[str]) -> None
     Raises:
         ColumnNotFoundError: If any of the columns in the list do not exist in the dataframe.
     """
-    invalid_columns = set(columns) - set(df.columns)
+    invalid_columns = sorted(set(columns) - set(df.columns))
     if invalid_columns:
         raise ColumnNotFoundError(f"Columns not found in dataframe: {invalid_columns}")

--- a/src/time_stream/utils.py
+++ b/src/time_stream/utils.py
@@ -1,8 +1,10 @@
+from collections.abc import Iterable
 from datetime import datetime
 
 import polars as pl
 
 from time_stream import Period
+from time_stream.exceptions import ColumnNotFoundError
 
 
 def get_date_filter(time_name: str, observation_interval: datetime | tuple[datetime, datetime | None]) -> pl.Expr:
@@ -125,3 +127,18 @@ def gap_size_count(df: pl.DataFrame, column: str) -> pl.DataFrame:
         ]
     )
     return df
+
+
+def check_columns_in_dataframe(df: pl.DataFrame, columns: Iterable[str]) -> None:
+    """Checks that columns exist in the dataframe.
+
+    Args:
+        df: DataFrame to check against
+        columns: Iterable of column names to check
+
+    Raises:
+        ColumnNotFoundError: If any of the columns in the list do not exist in the dataframe.
+    """
+    invalid_columns = set(columns) - set(df.columns)
+    if invalid_columns:
+        raise ColumnNotFoundError(f"Columns not found in dataframe: {invalid_columns}")

--- a/src/time_stream/utils.py
+++ b/src/time_stream/utils.py
@@ -1,12 +1,11 @@
 from datetime import datetime
-from typing import Tuple
 
 import polars as pl
 
 from time_stream import Period
 
 
-def get_date_filter(time_name: str, observation_interval: datetime | Tuple[datetime, datetime | None]) -> pl.Expr:
+def get_date_filter(time_name: str, observation_interval: datetime | tuple[datetime, datetime | None]) -> pl.Expr:
     """Get Polars expression for observation date interval filtering.
 
     Args:

--- a/src/time_stream/utils.py
+++ b/src/time_stream/utils.py
@@ -129,16 +129,19 @@ def gap_size_count(df: pl.DataFrame, column: str) -> pl.DataFrame:
     return df
 
 
-def check_columns_in_dataframe(df: pl.DataFrame, columns: Iterable[str]) -> None:
+def check_columns_in_dataframe(df: pl.DataFrame, columns: str | Iterable[str]) -> None:
     """Checks that columns exist in the dataframe.
 
     Args:
         df: DataFrame to check against
-        columns: Iterable of column names to check
+        columns: String or Iterable of column name(s) to check
 
     Raises:
         ColumnNotFoundError: If any of the columns in the list do not exist in the dataframe.
     """
+    if isinstance(columns, str):
+        columns = [str]
+
     invalid_columns = sorted(set(columns) - set(df.columns))
     if invalid_columns:
         raise ColumnNotFoundError(f"Columns not found in dataframe: {invalid_columns}")

--- a/tests/time_stream/test_aggregation.py
+++ b/tests/time_stream/test_aggregation.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import datetime
-from typing import Dict, List, Union, Type
+from typing import Type
 from unittest.mock import Mock
 
 import polars as pl
@@ -47,14 +47,14 @@ def generate_time_series(resolution: Period, periodicity: Period, length: int, m
 
 
 def generate_expected_df(
-        timestamps: List[datetime],
+        timestamps: list[datetime],
         aggregator: Type[AggregationFunction],
-        columns: Union[str, List[str]],
-        values: Dict[str, List[Union[float, int]]],
-        expected_counts: List[int],
-        actual_counts: List[int],
-        timestamps_of: List[datetime]=None,
-        valid: Dict[str, List[bool]]=None
+        columns: str | list[str],
+        values: dict[str, list[float | int]],
+        expected_counts: list[int],
+        actual_counts: list[int],
+        timestamps_of: list[datetime]=None,
+        valid: dict[str, list[bool]]=None
 ) -> pl.DataFrame:
     """Helper function to create a dataframe of expected results from an aggregation test.
 

--- a/tests/time_stream/test_base.py
+++ b/tests/time_stream/test_base.py
@@ -2039,7 +2039,7 @@ class TestGetattr(unittest.TestCase):
     def test_access_nonexistent_attribute(self):
         """Test accessing metadata key that doesn't exist"""
         ts = TimeSeries(self.df, time_name="time", column_metadata=self.column_metadata)
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(MetadataError):
             _ = ts.col1.key0
 
 

--- a/tests/time_stream/test_base.py
+++ b/tests/time_stream/test_base.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from polars.testing import assert_series_equal, assert_frame_equal
 
 from time_stream.base import TimeSeries
+from time_stream.exceptions import ColumnNotFoundError, ColumnTypeError, DuplicateTimeError, MetadataError, PeriodicityError, ResolutionError, TimeMutatedError
 from time_stream.enums import DuplicateOption
 from time_stream.period import Period
 from time_stream.columns import DataColumn, FlagColumn, PrimaryTimeColumn, SupplementaryColumn, TimeSeriesColumn
@@ -828,8 +829,12 @@ class TestValidateResolution(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", resolution=resolution)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(ResolutionError) as err:
                 ts._validate_resolution()
+            self.assertEqual(
+                f'Values in time field: "time" are not aligned to resolution: {resolution}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple monthly",
@@ -898,8 +903,12 @@ class TestValidateResolution(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", resolution=resolution)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(ResolutionError) as err:
                 ts._validate_resolution()
+            self.assertEqual(
+                f'Values in time field: "time" are not aligned to resolution: {resolution}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple daily",
@@ -959,8 +968,12 @@ class TestValidateResolution(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", resolution=resolution)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(ResolutionError) as err:
                 ts._validate_resolution()
+            self.assertEqual(
+                f'Values in time field: "time" are not aligned to resolution: {resolution}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple hourly",
@@ -1028,8 +1041,12 @@ class TestValidateResolution(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", resolution=resolution)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(ResolutionError) as err:
                 ts._validate_resolution()
+            self.assertEqual(
+                f'Values in time field: "time" are not aligned to resolution: {resolution}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple minute",
@@ -1094,8 +1111,12 @@ class TestValidateResolution(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", resolution=resolution)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(ResolutionError) as err:
                 ts._validate_resolution()
+            self.assertEqual(
+                f'Values in time field: "time" are not aligned to resolution: {resolution}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple seconds",
@@ -1159,8 +1180,12 @@ class TestValidateResolution(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", resolution=resolution)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(ResolutionError) as err:
                 ts._validate_resolution()
+            self.assertEqual(
+                f'Values in time field: "time" are not aligned to resolution: {resolution}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple microseconds",
@@ -1209,8 +1234,12 @@ class TestValidateResolution(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", resolution=resolution)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(ResolutionError) as err:
                 ts._validate_resolution()
+            self.assertEqual(
+                f'Values in time field: "time" are not aligned to resolution: {resolution}',
+                str(err.exception)
+            )
 
 
 class TestValidatePeriodicity(unittest.TestCase):
@@ -1272,8 +1301,12 @@ class TestValidatePeriodicity(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", periodicity=periodicity)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(PeriodicityError) as err:
                 ts._validate_periodicity()
+            self.assertEqual(
+                f'Values in time field: "time" do not conform to periodicity: {periodicity}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple monthly",
@@ -1337,8 +1370,12 @@ class TestValidatePeriodicity(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", periodicity=periodicity)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(PeriodicityError) as err:
                 ts._validate_periodicity()
+            self.assertEqual(
+                f'Values in time field: "time" do not conform to periodicity: {periodicity}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple daily",
@@ -1394,8 +1431,12 @@ class TestValidatePeriodicity(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", periodicity=periodicity)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(PeriodicityError) as err:
                 ts._validate_periodicity()
+            self.assertEqual(
+                f'Values in time field: "time" do not conform to periodicity: {periodicity}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple hourly",
@@ -1455,8 +1496,12 @@ class TestValidatePeriodicity(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", periodicity=periodicity)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(PeriodicityError) as err:
                 ts._validate_periodicity()
+            self.assertEqual(
+                f'Values in time field: "time" do not conform to periodicity: {periodicity}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple minute",
@@ -1512,8 +1557,12 @@ class TestValidatePeriodicity(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", periodicity=periodicity)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(PeriodicityError) as err:
                 ts._validate_periodicity()
+            self.assertEqual(
+                f'Values in time field: "time" do not conform to periodicity: {periodicity}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple seconds",
@@ -1569,8 +1618,12 @@ class TestValidatePeriodicity(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", periodicity=periodicity)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(PeriodicityError) as err:
                 ts._validate_periodicity()
+            self.assertEqual(
+                f'Values in time field: "time" do not conform to periodicity: {periodicity}',
+                str(err.exception)
+            )
 
     @parameterized.expand([
         ("simple microseconds",
@@ -1610,8 +1663,12 @@ class TestValidatePeriodicity(unittest.TestCase):
         """
         with patch.object(TimeSeries, '_setup'):
             ts = TimeSeries(pl.DataFrame({"time": times}), time_name="time", periodicity=periodicity)
-            with self.assertRaises(UserWarning):
+            with self.assertRaises(PeriodicityError) as err:
                 ts._validate_periodicity()
+            self.assertEqual(
+                f'Values in time field: "time" do not conform to periodicity: {periodicity}',
+                str(err.exception)
+            )
 
 
 class TestEpochCheck(unittest.TestCase):
@@ -1706,8 +1763,12 @@ class TestValidateTimeColumn(unittest.TestCase):
         """Test that a DataFrame missing the time column raises a ValueError."""
         invalid_df = pl.DataFrame(self.df["data_column"])
         ts = TimeSeries(self.df, time_name="time")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             ts._validate_time_column(invalid_df)
+        self.assertEqual(
+            f"Time column time not found in DataFrame. Available columns: {list(invalid_df.columns)}",
+            str(err.exception)
+        )
 
     def test_validate_time_column_mutated_timestamps(self):
         """Test that a DataFrame with mutated timestamps raises a ValueError."""
@@ -1715,8 +1776,12 @@ class TestValidateTimeColumn(unittest.TestCase):
         mutated_df = pl.DataFrame({
             "time": [datetime(1924, 1, 1), datetime(1924, 1, 2), datetime(1924, 1, 3)]
         })
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TimeMutatedError) as err:
             ts._validate_time_column(mutated_df)
+        self.assertEqual(f"Time column has been modified. Adding, removing or modifying time rows requires creating "
+                         f"a new TimeSeries instance.", str(err.exception))
+        assert_series_equal(self.df["time"], err.exception.old_timestamps)
+        assert_series_equal(mutated_df["time"], err.exception.new_timestamps)
 
     def test_validate_time_column_extra_timestamps(self):
         """Test that a DataFrame with extra timestamps raises a ValueError."""
@@ -1724,8 +1789,12 @@ class TestValidateTimeColumn(unittest.TestCase):
         extra_timestamps_df = pl.DataFrame({
             "time": list(ts.df["time"]) + [datetime(2024, 1, 4), datetime(2024, 1, 5)]
         })
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TimeMutatedError) as err:
             ts._validate_time_column(extra_timestamps_df)
+        self.assertEqual(f"Time column has been modified. Adding, removing or modifying time rows requires creating "
+                         f"a new TimeSeries instance.", str(err.exception))
+        assert_series_equal(self.df["time"], err.exception.old_timestamps)
+        assert_series_equal(extra_timestamps_df["time"], err.exception.new_timestamps)
 
     def test_validate_time_column_fewer_timestamps(self):
         """Test that a DataFrame with fewer timestamps raises a ValueError."""
@@ -1733,8 +1802,12 @@ class TestValidateTimeColumn(unittest.TestCase):
         fewer_timestamps_df = pl.DataFrame({
             "time": list(ts.df["time"])[:-1]
         })
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TimeMutatedError) as err:
             ts._validate_time_column(fewer_timestamps_df)
+        self.assertEqual(f"Time column has been modified. Adding, removing or modifying time rows requires creating "
+                         f"a new TimeSeries instance.", str(err.exception))
+        assert_series_equal(self.df["time"], err.exception.old_timestamps)
+        assert_series_equal(fewer_timestamps_df["time"], err.exception.new_timestamps)
 
 
 class TestRemoveMissingColumns(unittest.TestCase):
@@ -1889,20 +1962,23 @@ class TestSelectColumns(unittest.TestCase):
     def test_select_no_columns_raises_error(self):
         """Test selecting no columns raises error."""
         ts = TimeSeries(self.df, time_name="time", column_metadata=self.metadata)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             ts.select([])
+        self.assertEqual("No columns specified.", str(err.exception))
 
     def test_select_nonexistent_column(self):
         """Test selecting a column that does not exist raises error."""
         ts = TimeSeries(self.df, time_name="time", column_metadata=self.metadata)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             ts.select(["nonexistent_column"])
+        self.assertEqual(f"Columns not found in dataframe: ['nonexistent_column']", str(err.exception))
 
     def test_select_existing_and_nonexistent_column(self):
         """Test selecting a column that does not exist, alongside existing columns, still raises error"""
         ts = TimeSeries(self.df, time_name="time", column_metadata=self.metadata)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             ts.select(["col1", "col2", "nonexistent_column"])
+        self.assertEqual(f"Columns not found in dataframe: ['nonexistent_column']", str(err.exception))
 
     def test_select_column_doesnt_mutate_original_ts(self):
         """When selecting a column, the original ts should be unchanged"""
@@ -2005,9 +2081,9 @@ class TestGetItem(unittest.TestCase):
     def test_non_existent_column(self):
         """Test accessing non-existent data column raises error."""
         ts = TimeSeries(self.df, time_name="time", column_metadata=self.metadata)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             _ = ts["col0"]
-
+        self.assertEqual(f"Columns not found in dataframe: ['col0']", str(err.exception))
 
 class TestSetupColumns(unittest.TestCase):
     df = pl.DataFrame({
@@ -2031,21 +2107,23 @@ class TestSetupColumns(unittest.TestCase):
 
     def test_missing_supplementary_column_raises_error(self):
         """Test that an error raised when supplementary columns do not exist."""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             TimeSeries(df=self.df,
                        time_name="time",
                        supplementary_columns=["missing_col"],
                        flag_columns={"flag_col": "example_flag_system"},
                        flag_systems=self.flag_systems)
+        self.assertEqual("Columns not found in dataframe: ['missing_col']", str(err.exception))
 
     def test_missing_flag_column_raises_error(self):
         """Test that an error raised when flag columns do not exist."""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             TimeSeries(df=self.df,
                        time_name="time",
                        supplementary_columns=["supp_col"],
                        flag_columns={"missing_col": "example_flag_system"},
                        flag_systems=self.flag_systems)
+        self.assertEqual(f"Columns not found in dataframe: ['missing_col']", str(err.exception))
 
 
 class TestTimeColumn(unittest.TestCase):
@@ -2064,8 +2142,9 @@ class TestTimeColumn(unittest.TestCase):
         """Test that error is raised if no primary time column is found."""
         ts = TimeSeries(self.df, time_name="time")
         with patch.object(ts, "_columns", {}):  # Simulate missing columns
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ColumnNotFoundError) as err:
                 _ = ts.time_column
+            self.assertEqual("No single primary time column found.", str(err.exception))
 
     def test_multiple_time_columns_raises_error(self):
         """Test that error is raised if multiple primary time columns exist."""
@@ -2075,8 +2154,9 @@ class TestTimeColumn(unittest.TestCase):
                 "time1": PrimaryTimeColumn("time1", ts),
                 "time2": PrimaryTimeColumn("time2", ts),
             }):
-                with self.assertRaises(ValueError):
+                with self.assertRaises(ColumnNotFoundError) as err:
                     _ = ts.time_column
+                self.assertEqual("No single primary time column found.", str(err.exception))
 
 
 class TestTimeSeriesEquality(unittest.TestCase):
@@ -2212,8 +2292,9 @@ class TestColumnMetadata(unittest.TestCase):
 
     def test_retrieve_metadata_for_nonexistent_key_single_column(self):
         """Test that error raised when requesting a non-existent metadata key for an existing single column"""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(MetadataError) as err:
             self.ts.column_metadata("col1", "nonexistent_key")
+        self.assertEqual("Metadata key(s) ['nonexistent_key'] not found in any column.", str(err.exception))
 
     def test_retrieve_metadata_for_nonexistent_key_in_one_column(self):
         """Test that dict returned when requesting a metadata key exists in one column, but not another"""
@@ -2254,8 +2335,9 @@ class TestMetadata(unittest.TestCase):
 
     def test_retrieve_metadata_for_nonexistent_key_raises_error(self):
         """Test that an error is raised for a non-existent key."""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(MetadataError) as err:
             self.ts.metadata("nonexistent_key")
+        self.assertEqual(f"Metadata key 'nonexistent_key' not found", str(err.exception))
 
     def test_retrieve_metadata_for_nonexistent_key_strict_false(self):
         """Test that an empty result is returned when strict is false for non-existent key."""
@@ -2282,9 +2364,10 @@ class TestSetupMetadata(unittest.TestCase):
         """Test that providing a metadata key that conflicts with _columns raises a KeyError."""
         metadata = {"col1": 1234}
         with patch.object(TimeSeries, '_setup'):
-            with self.assertRaises(KeyError):
+            with self.assertRaises(MetadataError) as err:
                 ts = TimeSeries(self.df, time_name="time")
                 ts._setup_metadata(metadata)
+            self.assertEqual(f"Metadata key 'col1' exists as a Column in the Time Series.", str(err.exception))
 
     def test_setup_metadata_empty(self):
         """Test that passing an empty metadata dictionary leaves _metadata unchanged."""
@@ -2314,17 +2397,19 @@ class TestGetFlagSystemColumn(unittest.TestCase):
         """Test return when the specified data column doesn't exist"""
         data_column = "data_col_not_exist"
         flag_system = "example_flag_system"
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ColumnNotFoundError) as err:
             self.ts.get_flag_system_column(data_column, flag_system)
+        self.assertEqual("Data Column 'data_col_not_exist' not found.", str(err.exception))
 
     @parameterized.expand([
-        "supp_col", "flag_col"
+        ("supp_col", SupplementaryColumn), ("flag_col", FlagColumn)
     ])
-    def test_data_column_not_a_data_column(self, data_column):
+    def test_data_column_not_a_data_column(self, data_column, column_type):
         """Test return when the specified data column isn't actually a data column"""
         flag_system = "example_flag_system"
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError) as err:
             self.ts.get_flag_system_column(data_column, flag_system)
+        self.assertEqual(f"Column '{data_column}' is type {column_type}. Should be a data column.", str(err.exception))
 
     def test_get_expected_flag_column(self):
         """Test expected flag column returned for valid flag system"""
@@ -2383,8 +2468,14 @@ class TestHandleDuplicates(unittest.TestCase):
             # Omit the setup method so we have control over what we're testing
             ts = TimeSeries(df=self.df, time_name="time", on_duplicates="error")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(DuplicateTimeError) as err:
             ts._handle_duplicates()
+        self.assertEqual(
+            f"Duplicate time values found. A TimeSeries must have unique time values. Options for dealing with "
+            f"duplicate rows include: {[o.name for o in DuplicateOption]}.",
+            str(err.exception)
+        )
+        self.assertEqual([datetime(2024, 1, 1), datetime(2024, 1, 8)], err.exception.duplicates)
 
     def test_keep_first(self):
         """ Test that the keep first strategy works as expected
@@ -2507,8 +2598,14 @@ class TestHandleDuplicates(unittest.TestCase):
             # Omit the setup method so we have control over what we're testing
             ts = TimeSeries(df=self.df, time_name="time", on_duplicates=DuplicateOption.ERROR)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(DuplicateTimeError) as err:
             ts._handle_duplicates()
+        self.assertEqual(
+            f"Duplicate time values found. A TimeSeries must have unique time values. Options for dealing with "
+            f"duplicate rows include: {[o.name for o in DuplicateOption]}.",
+            str(err.exception)
+        )
+        self.assertEqual([datetime(2024, 1, 1), datetime(2024, 1, 8)], err.exception.duplicates)
 
 
 class TestPadTime(unittest.TestCase):

--- a/tests/time_stream/test_bitwise.py
+++ b/tests/time_stream/test_bitwise.py
@@ -1,6 +1,12 @@
 import unittest
 
 from time_stream.bitwise import BitwiseFlag
+from time_stream.exceptions import (
+    BitwiseFlagDuplicateError,
+    BitwiseFlagTypeError,
+    BitwiseFlagUnknownError,
+    BitwiseFlagValueError,
+)
 
 
 class Flags(BitwiseFlag):
@@ -18,19 +24,19 @@ class TestBitwiseFlag(unittest.TestCase):
 
     def test_invalid_flag_value_not_power_of_two(self):
         """Test that a non-power-of-two flag value raises error."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(BitwiseFlagValueError):
             class _Flags(BitwiseFlag):
                 INVALID_FLAG = 3
 
     def test_invalid_flag_value_negative(self):
         """Test that a negative flag value raises error."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(BitwiseFlagTypeError):
             class _Flags(BitwiseFlag):
                 INVALID_FLAG = -2
 
     def test_flag_uniqueness(self):
         """Test that duplicate flag values raise ValueError."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(BitwiseFlagDuplicateError):
             class _Flags(BitwiseFlag):
                 FLAG_A = 1
                 FLAG_B = 2
@@ -50,15 +56,15 @@ class TestBitwiseFlag(unittest.TestCase):
 
     def test_get_single_flag_invalid_integer(self):
         """Test that requesting an invalid integer flag raises error."""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(BitwiseFlagUnknownError):
             Flags.get_single_flag(3)  # 3 is a combination of 1 and 2, not a valid single flag
 
     def test_get_single_flag_invalid_string(self):
         """Test that requesting an invalid string flag raises error."""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(BitwiseFlagUnknownError):
             Flags.get_single_flag("FLAG_D")
 
     def test_get_single_flag_invalid_type(self):
         """Test that requesting a flag with an invalid type raises error."""
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BitwiseFlagTypeError):
             Flags.get_single_flag(3.5)

--- a/tests/time_stream/test_columns.py
+++ b/tests/time_stream/test_columns.py
@@ -5,9 +5,15 @@ import polars as pl
 from polars.testing import assert_series_equal
 
 from time_stream.base import TimeSeries
-from time_stream.bitwise import BitwiseMeta, ColumnRelationshipError
+from time_stream.bitwise import BitwiseMeta
 from time_stream.columns import DataColumn, FlagColumn, SupplementaryColumn
-from time_stream.exceptions import BitwiseFlagUnknownError
+from time_stream.exceptions import (
+    BitwiseFlagUnknownError,
+    ColumnNotFoundError,
+    ColumnRelationshipError,
+    ColumnTypeError,
+    MetadataError
+)
 from time_stream.relationships import Relationship, RelationshipType, DeletionPolicy
 
 
@@ -63,7 +69,7 @@ class TestMetadata(BaseTimeSeriesTest):
 
     def test_retrieve_metadata_for_nonexistent_key(self):
         """Test that error raised when requesting a non-existent metadata key"""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(MetadataError):
             self.column.metadata("nonexistent_key")
 
     def test_retrieve_metadata_for_nonexistent_key_strict_false(self):
@@ -381,13 +387,13 @@ class TestAddFlag(BaseTimeSeriesTest):
     def test_add_flag_to_data_column_raises_error(self):
         """ Test that trying to add a flag to a data column raises error"""
         column = DataColumn("data_col1", self.ts)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError):
             column.add_flag(1)
 
     def test_add_flag_to_supplementary_column_raises_error(self):
         """ Test that trying to add a flag to a supplementary column raises error"""
         column = SupplementaryColumn("supp_col", self.ts)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError):
             column.add_flag(1)
 
     def test_add_flag_twice(self):
@@ -482,13 +488,13 @@ class TestRemoveFlag(BaseTimeSeriesTest):
     def test_remove_flag_from_data_column_raises_error(self):
         """ Test that trying to remove a flag to a data column raises error"""
         column = DataColumn("data_col1", self.ts)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError):
             column.remove_flag(1)
 
     def test_remove_flag_from_supplementary_column_raises_error(self):
         """ Test that trying to remove a flag to a supplementary column raises error"""
         column = SupplementaryColumn("supp_col", self.ts)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError):
             column.remove_flag(1)
 
 
@@ -511,7 +517,7 @@ class TestGetattr(BaseTimeSeriesTest):
     def test_access_nonexistent_attribute(self):
         """Test accessing metadata key that doesn't exist"""
         column = DataColumn("data_col1", self.ts, self.metadata["data_col1"])
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(MetadataError):
             _ = column.key0
 
 
@@ -613,17 +619,17 @@ class TestAddRelationship(BaseTimeSeriesTest):
 
     def test_add_data_rel_to_data_column_raises_error(self):
         """ Test that can't set relationship between two data columns"""
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError):
             self.ts.data_col1.add_relationship("data_col2")
 
     def test_add_supp_rel_to_flag_column_raises_error(self):
         """ Test that can't set relationship between supplementary and flag columns"""
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError):
             self.ts.supp_col.add_relationship("flag_col")
 
     def test_add_flag_rel_to_supp_column_raises_error(self):
         """ Test that can't set relationship between flag and supplementary columns"""
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ColumnTypeError):
             self.ts.flag_col.add_relationship("supp_col")
 
     def test_flag_column_only_allowed_one_relationship(self):
@@ -708,5 +714,5 @@ class TestGetFlagSystemColumn(BaseTimeSeriesTest):
                                     DeletionPolicy.CASCADE)
         self.ts._relationship_manager._add(relationship)
 
-        with self.assertRaises(UserWarning):
+        with self.assertRaises(ColumnNotFoundError):
             self.ts.data_col1.get_flag_system_column(flag_system)

--- a/tests/time_stream/test_columns.py
+++ b/tests/time_stream/test_columns.py
@@ -5,8 +5,9 @@ import polars as pl
 from polars.testing import assert_series_equal
 
 from time_stream.base import TimeSeries
-from time_stream.bitwise import BitwiseMeta
+from time_stream.bitwise import BitwiseMeta, ColumnRelationshipError
 from time_stream.columns import DataColumn, FlagColumn, SupplementaryColumn
+from time_stream.exceptions import BitwiseFlagUnknownError
 from time_stream.relationships import Relationship, RelationshipType, DeletionPolicy
 
 
@@ -374,7 +375,7 @@ class TestAddFlag(BaseTimeSeriesTest):
     def test_adding_non_existent_flag_to_flag_column_raises_error(self):
         """ Test that trying to add an invalid flag to a valid flag column raises error"""
         column = FlagColumn("flag_col", self.ts, "example_flag_system", {})
-        with self.assertRaises(KeyError):
+        with self.assertRaises(BitwiseFlagUnknownError):
             column.add_flag(10)
 
     def test_add_flag_to_data_column_raises_error(self):
@@ -475,7 +476,7 @@ class TestRemoveFlag(BaseTimeSeriesTest):
     def test_removing_non_existent_flag_from_flag_column_raises_error(self):
         """ Test that trying to remove an invalid flag to a valid flag column raises error"""
         column = FlagColumn("flag_col", self.ts, "example_flag_system", {})
-        with self.assertRaises(KeyError):
+        with self.assertRaises(BitwiseFlagUnknownError):
             column.remove_flag(10)
 
     def test_remove_flag_from_data_column_raises_error(self):
@@ -627,7 +628,7 @@ class TestAddRelationship(BaseTimeSeriesTest):
 
     def test_flag_column_only_allowed_one_relationship(self):
         self.ts.flag_col.add_relationship("data_col1")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ColumnRelationshipError):
             self.ts.flag_col.add_relationship("data_col2")
 
 class TestRemoveRelationship(BaseTimeSeriesTest):

--- a/tests/time_stream/test_flag_manager.py
+++ b/tests/time_stream/test_flag_manager.py
@@ -8,6 +8,11 @@ from polars.testing import assert_series_equal
 from time_stream import TimeSeries
 from time_stream.bitwise import BitwiseFlag
 from time_stream.columns import FlagColumn
+from time_stream.exceptions import (
+    DuplicateColumnError,
+    DuplicateFlagSystemError,
+    FlagSystemNotFoundError
+)
 from time_stream.flag_manager import TimeSeriesFlagManager
 
 
@@ -49,7 +54,7 @@ class TestAddFlagSystem(BaseFlagManagerTest):
         """Test adding a duplicate flag system raises error."""
         flag_manager = TimeSeriesFlagManager(self.ts, self.flag_systems)
         new_flag_system = {"FLAG_A": 1, "FLAG_B": 2, "FLAG_C": 4}
-        with self.assertRaises(KeyError):
+        with self.assertRaises(DuplicateFlagSystemError):
             flag_manager.add_flag_system("quality_control", new_flag_system)
 
 
@@ -66,13 +71,13 @@ class TestInitFlagColumn(BaseFlagManagerTest):
     def test_init_flag_column_invalid_flag_system_raises_error(self):
         """Test initialising a flag column with a non-existent flag system raises error."""
         flag_manager = TimeSeriesFlagManager(self.ts, self.flag_systems)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(FlagSystemNotFoundError):
             flag_manager.init_flag_column("bad_system", "flag_column")
 
     def test_init_flag_column_invalid_column_name_raises_error(self):
         """Test initialising a flag column with a duplicate column name raises error."""
         flag_manager = TimeSeriesFlagManager(self.ts, self.flag_systems)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(DuplicateColumnError):
             flag_manager.init_flag_column("quality_control", "existing_flags")
 
     def test_init_flag_column_with_nonzero_default(self):

--- a/tests/time_stream/test_period.py
+++ b/tests/time_stream/test_period.py
@@ -2,17 +2,12 @@
 Unit tests for the period module
 """
 
-from collections.abc import (
-    Callable,
-)
 from dataclasses import (
     dataclass,
 )
 
-import collections
 import datetime
 import unittest
-import zoneinfo
 
 from typing import (
     Any,
@@ -23,6 +18,7 @@ from parameterized import parameterized
 import re
 
 import time_stream.period as p
+from time_stream.exceptions import PeriodConfigError, PeriodParsingError, PeriodValidationError
 from time_stream.period import Period
 
 
@@ -265,7 +261,7 @@ class TestOfOffsets(unittest.TestCase):
 
     def test_of_offsets_zero(self):
         """Test DateTimeAdjusters.of_offsets with zero month and microsecond offsets."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodConfigError):
             p.DateTimeAdjusters.of_offsets(0, 0)
 
 
@@ -281,7 +277,7 @@ class TestDateTimeAdjustersPostInit(unittest.TestCase):
     )
     def test_post_init_raises_with_none(self, name, retreat, advance):
         """Test DateTimeAdjusters.__post_init__ to ensure it raises AssertionError when retreat or advance is None."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodConfigError):
             p.DateTimeAdjusters(retreat=retreat, advance=advance).__post_init__()
 
 
@@ -571,7 +567,7 @@ class TestFmtTzdelta(unittest.TestCase):
     )
     def test_fmt_tzdelta_invalid(self, name, delta):
         """Test _fmt_tzdelta function with invalid timedelta objects."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodParsingError):
             p._fmt_tzdelta(delta)
 
 
@@ -819,7 +815,7 @@ class TestOfYears(unittest.TestCase):
 
     def test_zero_years(self):
         """Test Properties.of_years method with various year inputs."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_years(0)
 
 
@@ -847,7 +843,7 @@ class TestOfMonths(unittest.TestCase):
 
     def test_zero_months(self):
         """Test Properties.of_months method with zero month input."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_months(0)
 
 
@@ -875,7 +871,7 @@ class TestOfDays(unittest.TestCase):
 
     def test_zero_days(self):
         """Test Properties.of_days method with zero day input."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_days(0)
 
 
@@ -903,7 +899,7 @@ class TestOfHours(unittest.TestCase):
 
     def test_zero_hours(self):
         """Test Properties.of_hours method with zero hour input."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_hours(0)
 
 
@@ -931,7 +927,7 @@ class TestOfMinutes(unittest.TestCase):
 
     def test_zero_minutes(self):
         """Test Properties.of_minutes method with zero minute input."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_minutes(0)
 
 
@@ -959,7 +955,7 @@ class TestOfSeconds(unittest.TestCase):
 
     def test_zero_seconds(self):
         """Test Properties.of_seconds method with zero second input."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_seconds(0)
 
 
@@ -998,7 +994,7 @@ class TestOfMicroseconds(unittest.TestCase):
 
     def test_zero_microseconds(self):
         """Test Properties.of_microseconds method with zero microsecond input."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_microseconds(0)
 
 
@@ -1022,7 +1018,7 @@ class TestOfStepAndMultiplier(unittest.TestCase):
 
     def test_invalid_step(self):
         """Test Properties.of_step_and_multiplier method with invalid step input."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p.Properties.of_step_and_multiplier(999, 1)
 
 
@@ -1260,7 +1256,7 @@ class TestWithMonthOffset(unittest.TestCase):
         props = p.Properties(
             step=p._STEP_MONTHS, multiplier=12, month_offset=0, microsecond_offset=0, tzinfo=None, ordinal_shift=0
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             props.with_month_offset(-1)
 
 
@@ -1330,7 +1326,7 @@ class TestWithMicrosecondOffset(unittest.TestCase):
             tzinfo=None,
             ordinal_shift=0,
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             props.with_microsecond_offset(-1)
 
 
@@ -2511,7 +2507,7 @@ class TestPeriodOf(unittest.TestCase):
     @parameterized.expand(sorted(_BAD_ISO_DURATION | _BAD_DURATION))
     def test_bad(self, text: Any) -> None:
         """Test Period.of against a set of known bad arguments"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises((PeriodParsingError, PeriodValidationError)):
             Period.of(text)
 
 
@@ -2527,7 +2523,7 @@ class TestPeriodOfIsoDuration(unittest.TestCase):
     @parameterized.expand(sorted(_BAD_ISO_DURATION))
     def test_bad(self, text: Any) -> None:
         """Test Period.of_iso_duration against a set of known bad arguments"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises((PeriodParsingError, PeriodValidationError)):
             Period.of_iso_duration(text)
 
 
@@ -2543,7 +2539,7 @@ class TestPeriodOfDuration(unittest.TestCase):
     @parameterized.expand(sorted(_BAD_ISO_DURATION | _BAD_DURATION))
     def test_bad(self, text: Any) -> None:
         """Test Period.of_duration against a set of known bad arguments"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises((PeriodParsingError, PeriodValidationError)):
             Period.of_duration(text)
 
     @parameterized.expand(
@@ -2576,7 +2572,7 @@ class TestPeriodOfDateAndDuration(unittest.TestCase):
     @parameterized.expand(sorted(_BAD_DATE_AND_DURATION))
     def test_bad(self, text: Any) -> None:
         """Test Period.of_date_and_duration against a set of known bad arguments"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises((PeriodParsingError, PeriodValidationError)):
             Period.of_date_and_duration(text)
 
 
@@ -2592,7 +2588,7 @@ class TestPeriodOfRepr(unittest.TestCase):
     @parameterized.expand(sorted(_BAD_REPR))
     def test_bad(self, text: Any) -> None:
         """Test Period.of_repr against a set of known bad arguments"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises((PeriodParsingError, PeriodValidationError)):
             Period.of_repr(text)
 
 
@@ -2608,7 +2604,7 @@ class TestPeriodOfYears(unittest.TestCase):
     @parameterized.expand([-999, -1, 0])
     def test_bad(self, years: Any) -> None:
         """Test Period.of_years against a set of known bad years values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_years(years)
 
     @parameterized.expand(
@@ -2640,7 +2636,7 @@ class TestPeriodOfMonths(unittest.TestCase):
     @parameterized.expand([-1, 0])
     def test_bad(self, months: Any) -> None:
         """Test Period.of_months against a set of known bad months values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_months(months)
 
     @parameterized.expand(
@@ -2674,7 +2670,7 @@ class TestPeriodOfDays(unittest.TestCase):
     @parameterized.expand([-1, 0])
     def test_bad(self, days: Any) -> None:
         """Test Period.of_days against a set of known bad days values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_days(days)
 
     @parameterized.expand(
@@ -2706,7 +2702,7 @@ class TestPeriodOfHours(unittest.TestCase):
     @parameterized.expand([-1, 0])
     def test_bad(self, hours: Any) -> None:
         """Test Period.of_hours against a set of known bad hours values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_hours(hours)
 
     @parameterized.expand(
@@ -2740,7 +2736,7 @@ class TestPeriodOfMinutes(unittest.TestCase):
     @parameterized.expand([-1, 0])
     def test_bad(self, minutes: Any) -> None:
         """Test Period.of_minutes against a set of known bad minutes values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_minutes(minutes)
 
     @parameterized.expand(
@@ -2774,7 +2770,7 @@ class TestPeriodOfSeconds(unittest.TestCase):
     @parameterized.expand([-1, 0])
     def test_bad(self, seconds: Any) -> None:
         """Test Period.of_seconds against a set of known bad seconds values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_seconds(seconds)
 
     @parameterized.expand(
@@ -2809,7 +2805,7 @@ class TestPeriodOfMicroseconds(unittest.TestCase):
     @parameterized.expand([-1, 0])
     def test_bad(self, microseconds: Any) -> None:
         """Test Period.of_microseconds against a set of known bad microseconds values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_microseconds(microseconds)
 
     @parameterized.expand(
@@ -2859,7 +2855,7 @@ class TestPeriodOfTimedelta(unittest.TestCase):
     )
     def test_bad(self, timedelta: Any) -> None:
         """Test Period.of_timedelta against a set of known bad timedelta values"""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             Period.of_timedelta(timedelta)
 
     @parameterized.expand(

--- a/tests/time_stream/test_period.py
+++ b/tests/time_stream/test_period.py
@@ -16,8 +16,7 @@ import zoneinfo
 
 from typing import (
     Any,
-    Callable,
-    Optional,
+    Callable
 )
 from unittest.mock import patch, Mock
 from parameterized import parameterized
@@ -2949,7 +2948,7 @@ class TestPeriodTimedelta(unittest.TestCase):
     def test_is_valid(self, text: Any) -> None:
         """Test Period.timedelta property is valid for a set of Period instances"""
         period: Period = Period.of(text)
-        delta: Optional[datetime.timedelta] = period.timedelta
+        delta: datetime.timedelta = period.timedelta
         if delta is None:
             self.assertEqual(period._properties.step, p._STEP_MONTHS)
         else:
@@ -5379,10 +5378,10 @@ class TestPeriodWithTzinfo(unittest.TestCase):
             ("P1D", [TZ_UTC, None]),
         ]
     )
-    def test_offset_durations(self, name: Any, tz_info_list: list[Optional[datetime.tzinfo]]) -> None:
+    def test_offset_durations(self, name: Any, tz_info_list: list[datetime.tzinfo | None]) -> None:
         """Test Period.with_microsecond_offset method"""
         period: Period = Period.of_duration(name)
-        old_tz: datetime.tzinfo = None
+        old_tz: datetime.tzinfo | None = None
         for new_tz in tz_info_list:
             self.assertEqual(period.tzinfo, old_tz)
             period = period.with_tzinfo(new_tz)
@@ -6878,7 +6877,7 @@ class TestDateMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         dt: datetime.date = p._date_match(prefix, matcher)
         self.assertEqual(dt, d)
@@ -6891,7 +6890,7 @@ class TestTimeMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         tm: datetime.date = p._time_match(prefix, matcher)
         self.assertEqual(tm, t)
@@ -6913,7 +6912,7 @@ class TestTimezone(unittest.TestCase):
             ("-01:30", datetime.timezone(datetime.timedelta(hours=-1, minutes=-30))),
         ]
     )
-    def test_good(self, text: Any, tz: Optional[datetime.tzinfo]) -> None:
+    def test_good(self, text: Any, tz: datetime.tzinfo | None) -> None:
         self.assertEqual(tz, p._timezone(text))
 
 
@@ -6924,7 +6923,7 @@ class TestTzinfoMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         tz: datetime.date = p._tzinfo_match(prefix, matcher)
         self.assertEqual(tz, t.tzinfo)
@@ -6937,7 +6936,7 @@ class TestDatetimeMatch(unittest.TestCase):
     def test_good(self, text: Any, d: datetime.date, t: datetime.time) -> None:
         prefix: str = "d"
         regex = re.compile(p._datetime_regex(prefix))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         dt: datetime.date = p._datetime_match(prefix, matcher)
         answer: datetime.datetime = datetime.datetime.combine(date=d, time=t)
@@ -6961,7 +6960,7 @@ class TestMatchPeriod(unittest.TestCase):
     )
     def test_good(self, text: Any, iso: str) -> None:
         regex = re.compile(p._period_regex("period"))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_period(matcher)
         self.assertEqual(period, Period.of_iso_duration(iso))
@@ -6985,7 +6984,7 @@ class TestMatchPeriodOffset(unittest.TestCase):
     )
     def test_good(self, text: Any, duration: str) -> None:
         regex = re.compile(p._period_regex("period") + " -- " + p._period_regex("offset"))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_period_offset(matcher)
         self.assertEqual(period, Period.of_duration(duration))
@@ -7028,7 +7027,7 @@ class TestMatchDatetimePeriod(unittest.TestCase):
     )
     def test_good(self, text: Any, match_period: Period) -> None:
         regex = re.compile(p._datetime_regex("d") + r" -- " + p._period_regex("period"))
-        matcher: Optional[re.Match[str]] = regex.match(text)
+        matcher: re.Match[str] | None = regex.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_datetime_period(matcher)
         self.assertEqual(period, match_period)
@@ -7078,7 +7077,7 @@ class TestMatchRepr(unittest.TestCase):
         ]
     )
     def test_good(self, text: Any, match_period: Period) -> None:
-        matcher: Optional[re.Match[str]] = _REPR_REGEX.match(text)
+        matcher: re.Match[str] | None = _REPR_REGEX.match(text)
         self.assertNotEqual(matcher, None)
         period: Period = p._match_repr(matcher)
         self.assertEqual(period, match_period)
@@ -7086,7 +7085,7 @@ class TestMatchRepr(unittest.TestCase):
         ordinal: int = period.ordinal(shift_date)
         origin_date: datetime.datetime = period.datetime(ordinal)
         shift_amount: int = 0 - ordinal
-        matcher2: Optional[re.Match[str]] = _REPR_REGEX.match(f"{text}{shift_amount}")
+        matcher2: re.Match[str] | None = _REPR_REGEX.match(f"{text}{shift_amount}")
         self.assertNotEqual(matcher2, None)
         shifted_period: Period = p._match_repr(matcher2)
         ordinal2: int = shifted_period.ordinal(origin_date)

--- a/tests/time_stream/test_period.py
+++ b/tests/time_stream/test_period.py
@@ -3114,13 +3114,13 @@ class TestPeriodNaiveFormatter(unittest.TestCase):
     def test_bad(self, text: Any) -> None:
         """Test Period.naive_formatter method with bad arguments"""
         period: Period = Period.of(text)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodParsingError):
             period.naive_formatter("")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodParsingError):
             period.naive_formatter("x")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodParsingError):
             period.naive_formatter("  ")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodParsingError):
             period.naive_formatter("t ")
 
     @parameterized.expand(
@@ -6364,7 +6364,7 @@ class TestGetOffsetPeriod(unittest.TestCase):
         base_properties: p.Properties = base_period._properties
         self.assertEqual(base_period, p._get_offset_period(base_properties))
         shifted_properties: p.Properties = base_properties.with_ordinal_shift(1)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p._get_offset_period(shifted_properties)
         offset_properties: p.Properties = base_properties.with_microsecond_offset(1)
         offset_period: Period = p._get_offset_period(offset_properties)
@@ -6381,10 +6381,10 @@ class TestGetBasePeriod(unittest.TestCase):
         base_properties: p.Properties = base_period._properties
         self.assertEqual(base_period, p._get_base_period(base_properties))
         shifted_properties: p.Properties = base_properties.with_ordinal_shift(1)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p._get_base_period(shifted_properties)
         offset_properties: p.Properties = base_properties.with_microsecond_offset(1)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(PeriodValidationError):
             p._get_base_period(offset_properties)
 
 

--- a/tests/time_stream/test_period.py
+++ b/tests/time_stream/test_period.py
@@ -2051,7 +2051,7 @@ class TestMonthsSecondsPostInit(unittest.TestCase):
     )
     def test_post_init_invalid(self, name, string, months, seconds, microseconds):
         """Test __post_init__ method with invalid periods."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodValidationError):
             p.MonthsSeconds(string, months, seconds, microseconds)
 
 
@@ -2078,7 +2078,7 @@ class TestGetStepAndMultiplier(unittest.TestCase):
     def test_get_step_and_multiplier_invalid(self, name, string, months, seconds, microseconds):
         """Test get_step_and_multiplier method with invalid periods."""
         period = p.MonthsSeconds(string, months, seconds, microseconds)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodValidationError):
             period.get_step_and_multiplier()
 
 
@@ -2121,7 +2121,7 @@ class TestMonthsSecondsGetBaseProperties(unittest.TestCase):
     def test_get_base_properties_invalid(self, name, string, months, seconds, microseconds):
         """Test get_base_properties method with invalid periods."""
         period = p.MonthsSeconds(string, months, seconds, microseconds)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodValidationError):
             period.get_base_properties()
 
 
@@ -2159,7 +2159,7 @@ class TestPeriodFieldsPostInit(unittest.TestCase):
     )
     def test_post_init_invalid(self, name, string, years, months, days, hours, minutes, seconds, microseconds):
         """Test __post_init__ method with invalid periods."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PeriodValidationError):
             p.PeriodFields(string, years, months, days, hours, minutes, seconds, microseconds)
 
 

--- a/tests/time_stream/test_qc.py
+++ b/tests/time_stream/test_qc.py
@@ -7,6 +7,12 @@ from parameterized import parameterized
 from polars.testing import assert_series_equal
 
 from time_stream.base import TimeSeries
+from time_stream.exceptions import (
+    ColumnNotFoundError,
+    QcUnknownOperatorError,
+    QcTypeError,
+    UnknownQcError
+)
 from time_stream.qc import QCCheck, ComparisonCheck, SpikeCheck, RangeCheck
 
 
@@ -61,7 +67,7 @@ class TestQCCheck(unittest.TestCase):
     ])
     def test_get_with_invalid_string(self, get_input):
         """Test QCCheck.get() with invalid string."""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(UnknownQcError):
             QCCheck.get(get_input)
 
     def test_get_with_invalid_class(self):
@@ -70,7 +76,7 @@ class TestQCCheck(unittest.TestCase):
         class InvalidClass:
             pass
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(QcTypeError):
             QCCheck.get(InvalidClass)  # noqa - expecting type warning
 
     @parameterized.expand([
@@ -78,7 +84,7 @@ class TestQCCheck(unittest.TestCase):
     ])
     def test_get_with_invalid_type(self, get_input):
         """Test QCCheck.get() with invalid type."""
-        with self.assertRaises(TypeError):
+        with self.assertRaises(QcTypeError):
             QCCheck.get(get_input)
 
 
@@ -161,7 +167,7 @@ class TestComparisonCheck(unittest.TestCase):
     def test_invalid_operator(self):
         """ Test that invalid operator raises error
         """
-        with self.assertRaises(KeyError):
+        with self.assertRaises(QcUnknownOperatorError):
             check = ComparisonCheck(10, ">>")
             check.apply(self.ts, "value_a")
 

--- a/tests/time_stream/test_relationships.py
+++ b/tests/time_stream/test_relationships.py
@@ -8,6 +8,7 @@ import polars as pl
 
 from time_stream import TimeSeries
 from time_stream.relationships import Relationship, RelationshipManager, RelationshipType, DeletionPolicy
+from time_stream.exceptions import ColumnRelationshipError
 
 
 class BaseRelationshipTest(unittest.TestCase):
@@ -135,7 +136,7 @@ class TestRelationshipManagerAdd(BaseRelationshipTest):
         self.relationship_manager._add(relationship1)
 
         relationship2 = Relationship(self.ts.colA, self.ts.colC, RelationshipType.ONE_TO_ONE, deletion_policy)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ColumnRelationshipError):
             self.relationship_manager._add(relationship2)
 
     @parameterized.expand([(str(d), d) for d in DeletionPolicy])
@@ -145,7 +146,7 @@ class TestRelationshipManagerAdd(BaseRelationshipTest):
         self.relationship_manager._add(relationship1)
 
         relationship2 = Relationship(self.ts.colA, self.ts.colC, RelationshipType.MANY_TO_ONE, deletion_policy)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ColumnRelationshipError):
             self.relationship_manager._add(relationship2)
 
     @parameterized.expand([(str(d), d) for d in DeletionPolicy])
@@ -198,7 +199,7 @@ class TestRelationshipManagerAdd(BaseRelationshipTest):
         relationship2 = Relationship(self.ts.colB, self.ts.colC, RelationshipType.MANY_TO_MANY, deletion_policy)
 
         self.relationship_manager._add(relationship1)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ColumnRelationshipError):
             self.relationship_manager._add(relationship2)
 
 
@@ -334,10 +335,10 @@ class TestRelationshipManagerHandleDeletion(BaseRelationshipTest):
         relationship = Relationship(self.ts.colA, self.ts.colB, RelationshipType.ONE_TO_ONE, DeletionPolicy.RESTRICT)
         self.ts._relationship_manager._add(relationship)
 
-        with self.assertRaises(UserWarning):
+        with self.assertRaises(ColumnRelationshipError):
             self.ts._relationship_manager._handle_deletion(self.ts.colA)
 
-        with self.assertRaises(UserWarning):
+        with self.assertRaises(ColumnRelationshipError):
             self.ts._relationship_manager._handle_deletion(self.ts.colB)
 
 


### PR DESCRIPTION
Trying to bring some more consistency to the error handling and use of exceptions across the module. 

## Changes:
- Custom exceptions created in an `exceptions.py` module, to be used for specific errors across the package
  - All inherit from a base `TimeStreamError` - so more easily catchable by code using the package
- No UserWarnings left in code base
- No assert statements used as error handling
- Tried to improve error messages to include helpful, actionable statements

### Future improvements:
- Lots of duplicated error handling in Period module - could be streamlined


