### PR TITLE
Update get_date_filter

### DIFF
--- a/src/time_stream/utils.py
+++ b/src/time_stream/utils.py
@@ -33,7 +33,7 @@ def get_date_filter(
         start_date, end_date = observation_interval
 
     if start_date is None and end_date is None:
-        return pl.lit(True)
+        return pl.lit(True).alias(time_name)
 
     if start_date is not None and end_date is None:
         return pl.col(time_name) >= start_date

--- a/tests/time_stream/test_utils.py
+++ b/tests/time_stream/test_utils.py
@@ -77,7 +77,7 @@ class TestGetDateFilter:
         self, observation_interval: datetime | tuple[datetime, datetime | None], expected_eval: list
     ) -> None:
         date_filter = get_date_filter("timestamp", observation_interval)
-        result = self.df.select(date_filter).to_series()
+        result = self.df.with_columns(date_filter).to_series()
         expected = pl.Series("timestamp", expected_eval)
         assert_series_equal(result, expected)
 


### PR DESCRIPTION
Needed to update this util function to handle when both start and end date are None (essentially returning a "no filter" expression).