### PR TITLE
FPM-904 - Modifications to flatline QC check

### DIFF
--- a/docs/source/user_guide/quality_control.rst
+++ b/docs/source/user_guide/quality_control.rst
@@ -51,29 +51,14 @@ The :meth:`~time_stream.TimeFrame.qc_check` method applies a single QC check to 
 It can return a boolean mask (for filtering) or update the TimeFrame with a new column containing the results
 of the QC check. Each QC check is configurable through parameters specific to that check - see examples below.
 
-Available checks
+Comparison check
 ----------------
 
-- ``"comparison"`` - **compare values against a constant or list using operators:**
-  ``<, <=, >, >=, ==, !=, is_in``
+Compare values against a constant or list using operators: ``<, <=, >, >=, ==, !=, is_in``.
 
-  Use for value thresholds or list of error codes.
+Use for value thresholds or lists of error codes.
 
-- ``"range"`` - **check if values lie inside/outside a min–max interval.**
-
-  Use for physical plausibility bounds (e.g. temperature between −50 and 50 °C).
-
-- ``"time_range"`` - **flag data between specific time ranges.**
-
-  Use for known bad periods such as sensor outages or calibration times.
-
-- ``"spike"`` - **detect sudden jumps using neighbour differences.**
-
-  Use for unrealistic single-point spikes.
-
-**Examples:**
-
-1. Temperature greater than or equal to 50
+**Example: Temperature greater than or equal to 50:**
 
 .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
    :language: python
@@ -87,7 +72,7 @@ Available checks
    import examples_quality_control
    examples_quality_control.comparison_qc_1()
 
-2. Sensor codes within a list
+**Example: Sensor codes within a list:**
 
 .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
    :language: python
@@ -101,8 +86,14 @@ Available checks
    import examples_quality_control
    examples_quality_control.comparison_qc_3()
 
+Range check
+-----------
 
-3. Temperatures outside of min and max range (below -30 and above 50)
+Check if values lie inside or outside a min-max interval.
+
+Use for physical plausibility bounds (e.g. temperature between -30 and 50 °C).
+
+**Example: Temperatures outside of the range -30 to 50:**
 
 .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
    :language: python
@@ -116,7 +107,14 @@ Available checks
    import examples_quality_control
    examples_quality_control.range_qc_1()
 
-4. Flag rainfall values between the hours of 01:00 and 03:00
+Time range check
+----------------
+
+Flag data between specific time ranges.
+
+Use for known bad periods such as sensor outages or calibration times.
+
+**Example: Flag rainfall values between the hours of 01:00 and 03:00:**
 
 .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
    :language: python
@@ -130,7 +128,7 @@ Available checks
    import examples_quality_control
    examples_quality_control.time_range_qc_1()
 
-5. Flag temperature values between 03:30 on the 1st January and 09:30 on the 1st January
+**Example: Flag temperature values between 03:30 and 09:30 on the 1st January:**
 
 .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
    :language: python
@@ -142,9 +140,16 @@ Available checks
    :hide-code:
 
    import examples_quality_control
-   ts = examples_quality_control.time_range_qc_2()
+   examples_quality_control.time_range_qc_2()
 
-6. Spike check on temperature data
+Spike check
+-----------
+
+Detect sudden jumps using neighbour differences.
+
+Use for unrealistic single-point spikes.
+
+**Example: Spike check on temperature data:**
 
 .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
    :language: python
@@ -156,15 +161,73 @@ Available checks
    :hide-code:
 
    import examples_quality_control
-   ts = examples_quality_control.spike_qc_1()
+   examples_quality_control.spike_qc_1()
 
 .. note::
-    The result doesn't flag the neighbouring high values of 50, 52. The spike test is really for detecting a sudden
-    jump with one value between "normal" values.
+    The result doesn't flag the neighbouring high values of 50 and 52. The spike test detects a sudden
+    jump where one value sits between otherwise normal values.
 
 .. note::
-    The result return ``null`` for the first and last values; the spike test relies of comparisons of neighbouring
-    values.
+    The result returns ``null`` for the first and last values; the spike test relies on comparisons with
+    neighbouring values.
+
+Flat line check
+---------------
+
+Detect consecutive repeated (or near-repeated) values.
+
+Use when a sensor stuck at a fixed value should be flagged as suspect.
+
+**Example: Flag temperature values stuck at the same reading for 3 or more consecutive timesteps:**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+   :language: python
+   :start-after: [start_block_11]
+   :end-before: [end_block_11]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_quality_control
+   examples_quality_control.flat_line_qc_1()
+
+**Example: Using** ``ignore_value`` **- suppress flagging when the repeated value is 0.0:**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+   :language: python
+   :start-after: [start_block_12]
+   :end-before: [end_block_12]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_quality_control
+   examples_quality_control.flat_line_qc_2()
+
+.. note::
+    More than one ``ignore_value`` can be specified in a list, e.g. [0.0, 20.0]
+
+**Example: Using** ``tolerance`` **- flag values that barely change (within 0.01) for 3 or more consecutive readings:**
+
+The data below drifts slightly around 20 °C (varying by less than 0.01 between readings) before jumping
+to a different range. The ``tolerance`` parameter catches these near-flat runs that exact equality would miss.
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+   :language: python
+   :start-after: [start_block_13]
+   :end-before: [end_block_13]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_quality_control
+   examples_quality_control.flat_line_qc_3()
+
+Additional parameters
+=====================
 
 Observation interval
 --------------------

--- a/src/time_stream/examples/examples_quality_control.py
+++ b/src/time_stream/examples/examples_quality_control.py
@@ -31,7 +31,7 @@ def comparison_qc_1() -> None:
         "comparison", "temperature", compare_to=50, operator=">=", into=True
     )
     # [end_block_2]
-    print(tf)
+    print(tf.df)
     # fmt: on
 
 
@@ -46,7 +46,7 @@ def comparison_qc_3() -> None:
         "comparison", "sensor_codes", compare_to=error_codes, operator="is_in", into=True
     )
     # [end_block_4]
-    print(tf)
+    print(tf.df)
     # fmt: on
 
 
@@ -58,14 +58,14 @@ def range_qc_1() -> None:
     tf = tf.qc_check(
         "range",
         "temperature",
-        min_value=-10,
+        min_value=-30,
         max_value=50,
         closed="none",  # Range is not inclusive of min and max value
         within=False,  # Flag values outside of this range
         into=True,
     )
     # [end_block_5]
-    print(tf)
+    print(tf.df)
 
 
 def spike_qc_1() -> None:
@@ -78,7 +78,7 @@ def spike_qc_1() -> None:
         "spike", "temperature", threshold=10.0, into=True
     )
     # [end_block_7]
-    print(tf)
+    print(tf.df)
     # fmt: on
 
 
@@ -96,7 +96,7 @@ def time_range_qc_1() -> None:
         into=True
     )
     # [end_block_9]
-    print(tf)
+    print(tf.df)
     # fmt: on
 
 
@@ -113,4 +113,61 @@ def time_range_qc_2() -> None:
         into=True,
     )
     # [end_block_10]
-    print(tf)
+    print(tf.df)
+
+
+def create_flat_line_time_series() -> ts.TimeFrame:
+    dates = [datetime(2023, 1, 1) + timedelta(hours=i) for i in range(10)]
+    temperature = [18.0, 20.0, 20.0, 20.0, 20.0, 22.0, 21.0, 0.0, 0.0, 0.0]
+    df = pl.DataFrame({"timestamp": dates, "temperature": temperature})
+    return ts.TimeFrame(df=df, time_name="timestamp")
+
+
+def create_near_flat_line_time_series() -> ts.TimeFrame:
+    dates = [datetime(2023, 1, 1) + timedelta(hours=i) for i in range(10)]
+    # Values drift slightly around 20, then jump to 22 and drift slightly around 21
+    temperature = [18.0, 20.0, 20.005, 20.001, 19.991, 22.0, 20.99, 21.003, 21.009, 20.997]
+    df = pl.DataFrame({"timestamp": dates, "temperature": temperature})
+    return ts.TimeFrame(df=df, time_name="timestamp")
+
+
+def flat_line_qc_1() -> None:
+    # fmt: off
+    with suppress_output():
+        tf = create_flat_line_time_series()
+
+    # [start_block_11]
+    tf = tf.qc_check(
+        "flat_line", "temperature", min_count=3, into=True
+    )
+    # [end_block_11]
+    print(tf.df)
+    # fmt: on
+
+
+def flat_line_qc_2() -> None:
+    # fmt: off
+    with suppress_output():
+        tf = create_flat_line_time_series()
+
+    # [start_block_12]
+    tf = tf.qc_check(
+        "flat_line", "temperature", min_count=3, ignore_value=0.0, into=True
+    )
+    # [end_block_12]
+    print(tf.df)
+    # fmt: on
+
+
+def flat_line_qc_3() -> None:
+    # fmt: off
+    with suppress_output():
+        tf = create_near_flat_line_time_series()
+
+    # [start_block_13]
+    tf = tf.qc_check(
+        "flat_line", "temperature", min_count=3, tolerance=0.1, into=True
+    )
+    # [end_block_13]
+    print(tf.df)
+    # fmt: on

--- a/src/time_stream/qc.py
+++ b/src/time_stream/qc.py
@@ -9,6 +9,7 @@ It supports various QC checks including:
 - RangeCheck: Verify values fall within or outside a given range.
 - TimeRangeCheck: Apply range checks directly to the time column.
 - SpikeCheck: Detect sudden spikes based on differences with neighbors.
+- FlatLineCheck: Detect flat lines by checking for consecutive repeated values.
 """
 
 from abc import ABC, abstractmethod
@@ -114,7 +115,7 @@ class ComparisonCheck(QCCheck):
     name = "comparison"
 
     def __init__(self, compare_to: float | list, operator: str, flag_na: bool = False) -> None:
-        """Initialize comparison check.
+        """Initialise comparison check.
 
         Args:
             compare_to: The value for comparison.
@@ -160,7 +161,7 @@ class RangeCheck(QCCheck):
         closed: str | ClosedInterval = "both",
         within: bool = True,
     ) -> None:
-        """Initialize range check.
+        """Initialise range check.
 
         Args:
             min_value: Minimum of the range.
@@ -244,7 +245,7 @@ class SpikeCheck(QCCheck):
     name = "spike"
 
     def __init__(self, threshold: float):
-        """Initialize spike detection check.
+        """Initialise spike detection check.
 
         Args:
             threshold: The spike detection threshold.
@@ -277,47 +278,68 @@ class SpikeCheck(QCCheck):
 
 @QCCheck.register
 class FlatLineCheck(QCCheck):
-    """Detect flat lines by checking number of repeated values."""
+    """Detect flat lines by checking for consecutive repeated values."""
 
     name = "flat_line"
 
-    def __init__(self, threshold: float, ignore_values: float | list | None = None):
-        """Initialize flat line detection check.
+    def __init__(
+        self,
+        min_count: int,
+        tolerance: float | None = None,
+        ignore_value: int | float | str | list | None = None,
+    ) -> None:
+        """Initialise flat line detection check.
 
         Args:
-            threshold: Number of repeated values to consider flat lining.
-            ignore_values: Optional list of values to ignore when checking for flat lines (e.g., 0's).
+            min_count: Minimum number of consecutive repeated values required for a flat line. Must be at least 2.
+            tolerance: Optional tolerance for near-equality comparison. When set, consecutive values differing by
+                less than or equal to this amount are considered equal. Only valid for numeric columns.
+                Defaults to None (exact equality).
+            ignore_value: Optional value or list of values that are allowed to repeat without being flagged.
+                For float columns, int values are automatically upcast to float. For all other column types,
+                values must match the column's type exactly.
         """
-        self.threshold = threshold
+        if min_count < 2:
+            raise ValueError("min_count for flat line check must be at least 2")
+        self.min_count = min_count
+        self.tolerance = tolerance
         self.ignore_values = (
-            ignore_values if isinstance(ignore_values, list) else ([ignore_values] if ignore_values is not None else [])
+            ignore_value if isinstance(ignore_value, list) else ([ignore_value] if ignore_value is not None else [])
         )
 
     def expr(self, ctx: QcCtx, column: str) -> pl.Expr:
         """Return the Polars expression for flat line detection.
 
-        Repeated nulls do not count as flat lines.
+        Repeated nulls do not count as flat lines. Null values break flat line groups.
         """
-        if self.threshold < 2:
-            raise ValueError("Threshold for flat line check must be at least 2")
-
         prev = pl.col(column).shift(1)
 
-        # Treat "equal to previous" such that two nulls are not considered equal
-        equal_prev = pl.col(column).is_not_null() & prev.is_not_null() & (pl.col(column) == prev)
+        # Treat "equal to previous" such that two nulls are not considered equal.
+        # When tolerance is set, use absolute difference; otherwise use exact equality.
+        if self.tolerance is None:
+            equal_to_prev = pl.col(column).is_not_null() & prev.is_not_null() & (pl.col(column) == prev)
+        else:
+            equal_to_prev = (
+                pl.col(column).is_not_null() & prev.is_not_null() & ((pl.col(column) - prev).abs() <= self.tolerance)
+            )
 
         # Mark starts of new groups, then create a group id by cumulative sum
-        change = (~equal_prev).cast(pl.Int32)
+        change = (~equal_to_prev).cast(pl.Int32)
         group_id = change.cum_sum()
 
         # Size of each group
-        group_size = pl.count().over(group_id)
+        group_size = pl.len().over(group_id)
 
         # Only consider non-null groups for flat-line detection
-        result = (group_size >= self.threshold) & pl.col(column).is_not_null()
+        result = (group_size >= self.min_count) & pl.col(column).is_not_null()
 
         # Apply ignore-values if provided
         if self.ignore_values:
-            result = result & ~pl.col(column).is_in(self.ignore_values)
+            dtype = ctx.df.schema[column]
+            try:
+                ignore_list = pl.Series("", self.ignore_values, dtype=dtype, strict=True).to_list()
+            except Exception as e:
+                raise TypeError(f"ignore_value is incompatible with column '{column}' of type {dtype}: {e}") from e
+            result = result & ~pl.col(column).is_in(ignore_list)
 
         return result

--- a/tests/time_stream/test_qc.py
+++ b/tests/time_stream/test_qc.py
@@ -614,7 +614,7 @@ class TestFlatLineCheck:
     tf = TimeFrame(data, "time")
 
     @pytest.mark.parametrize(
-        "threshold,data,expected",
+        "min_count,data,expected",
         [
             (
                 2,
@@ -645,23 +645,23 @@ class TestFlatLineCheck:
         ids=[
             "simple_flat_line",
             "from_start",
-            "flatline_len_is_threshold",
+            "flatline_len_is_min_count",
             "at_end",
-            "flat_line_below_threshold",
+            "flat_line_below_min_count",
         ],
     )
-    def test_flat_line_threshold(self, threshold: int, data: list[float], expected: list[bool]) -> None:
-        """Test that the flat line check works correctly with different thresholds."""
+    def test_flat_line_min_count(self, min_count: int, data: list[float], expected: list[bool]) -> None:
+        """Test that the flat line check works correctly with different min_count values."""
         df = self.tf.df.with_columns(pl.Series(data).alias("value_a"))
         tf = self.tf.with_df(df)
 
-        check = FlatLineCheck(threshold)
+        check = FlatLineCheck(min_count)
         result = check.apply(tf.df, tf.time_name, "value_a")
         expected_series = pl.Series(expected)
         assert_series_equal(result, expected_series)
 
     @pytest.mark.parametrize(
-        "threshold,data,expected",
+        "min_count,data,expected",
         [
             (
                 3,
@@ -684,35 +684,30 @@ class TestFlatLineCheck:
             "2_flat_lines",
             "1_too_small",
             "flatlines_on_ends",
-            "flat_lines_below_threshold",
+            "flat_lines_below_min_count",
         ],
     )
-    def test_multiple_flat_lines(self, threshold: int, data: list[float], expected: list[bool]) -> None:
+    def test_multiple_flat_lines(self, min_count: int, data: list[float], expected: list[bool]) -> None:
         """Test that multiple flat lines are correctly identified."""
         df = self.tf.df.with_columns(pl.Series(data).alias("value_a"))
         tf = self.tf.with_df(df)
 
-        check = FlatLineCheck(threshold)
+        check = FlatLineCheck(min_count)
         result = check.apply(tf.df, tf.time_name, "value_a")
         expected_series = pl.Series(expected)
         assert_series_equal(result, expected_series)
 
     @pytest.mark.parametrize(
-        "threshold",
-        [
-            (1),
-            (0),
-            (-2),
-        ],
+        "min_count",
+        [1, 0, -2],
     )
-    def test_bad_threshold(self, threshold: int) -> None:
-        """Threshold of 1 means that any repeated value will be flagged as a flat line.  Check this is not the case."""
-        check = FlatLineCheck(threshold)
-        with pytest.raises(ValueError, match="Threshold for flat line check must be at least 2"):
-            check.apply(self.tf.df, self.tf.time_name, "value_a")
+    def test_bad_min_count(self, min_count: int) -> None:
+        """Test that min_count values below 2 raise a ValueError at construction time."""
+        with pytest.raises(ValueError, match="min_count for flat line check must be at least 2"):
+            FlatLineCheck(min_count)
 
     @pytest.mark.parametrize(
-        "threshold,data,expected",
+        "min_count,data,expected",
         [
             (
                 3,
@@ -742,18 +737,18 @@ class TestFlatLineCheck:
             "single_null_at_end",
         ],
     )
-    def test_with_trailing_null_values(self, threshold: int, data: list[float], expected: list[bool]) -> None:
+    def test_with_trailing_null_values(self, min_count: int, data: list[float], expected: list[bool]) -> None:
         """Test that null values at beginning and end are not seen as flat lines."""
         df = self.tf.df.with_columns(pl.Series(data).alias("value_a"))
         tf = self.tf.with_df(df)
 
-        check = FlatLineCheck(threshold)
+        check = FlatLineCheck(min_count)
         result = check.apply(tf.df, tf.time_name, "value_a")
         expected_series = pl.Series(expected)
         assert_series_equal(result, expected_series)
 
     @pytest.mark.parametrize(
-        "threshold,data,expected",
+        "min_count,data,expected",
         [
             (
                 3,
@@ -777,18 +772,18 @@ class TestFlatLineCheck:
             "all_nulls",
         ],
     )
-    def test_null_values_not_flatline(self, threshold: int, data: list[float], expected: list[bool]) -> None:
+    def test_null_values_not_flatline(self, min_count: int, data: list[float], expected: list[bool]) -> None:
         """Test that null values are not considered as part of a flat line."""
         df = self.tf.df.with_columns(pl.Series(data).alias("value_a"))
         tf = self.tf.with_df(df)
 
-        check = FlatLineCheck(threshold)
+        check = FlatLineCheck(min_count)
         result = check.apply(tf.df, tf.time_name, "value_a")
         expected_series = pl.Series(expected)
         assert_series_equal(result, expected_series)
 
     @pytest.mark.parametrize(
-        "threshold,data,expected",
+        "min_count,data,expected",
         [
             (
                 3,
@@ -818,52 +813,179 @@ class TestFlatLineCheck:
             "nulls_but_no_flatline",
         ],
     )
-    def test_with_inner_null_values(self, threshold: int, data: list[float], expected: list[bool]) -> None:
+    def test_with_inner_null_values(self, min_count: int, data: list[float], expected: list[bool]) -> None:
         """Test that null values in the middle of a flat line are not counted, and break the flat line."""
         df = self.tf.df.with_columns(pl.Series(data).alias("value_a"))
         tf = self.tf.with_df(df)
 
-        check = FlatLineCheck(threshold)
+        check = FlatLineCheck(min_count)
         result = check.apply(tf.df, tf.time_name, "value_a")
         expected_series = pl.Series(expected)
         assert_series_equal(result, expected_series)
 
     @pytest.mark.parametrize(
-        "threshold,ignore,data,expected",
+        "min_count,ignore,data,col_dtype,expected",
         [
             (
                 3,
                 1.0,
                 [1.0, 1.0, 1.0, 1.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                pl.Float64,
                 [False, False, False, False, False, False, False, False, False],
             ),
             (
                 3,
                 [1.0],
                 [1.0, 1.0, 1.0, None, 1.0, 6.0, 7.0, 8.0, 9.0],
+                pl.Float64,
                 [False, False, False, False, False, False, False, False, False],
             ),
             (
                 3,
                 [2.0, 3.0],
                 [1.0, 1.0, 1.0, None, 1.0, 1.0, 1.0, 8.0, 9.0],
+                pl.Float64,
                 [True, True, True, False, True, True, True, False, False],
+            ),
+            (
+                3,
+                0,
+                [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 5.0, 6.0, 7.0],
+                pl.Float64,
+                [False, False, False, True, True, True, False, False, False],
+            ),
+            (
+                3,
+                [0, 3.1],
+                [0.0, 0.0, 0.0, 3.1, 3.1, 3.1, 5.0, 6.0, 7.0],
+                pl.Float64,
+                [False, False, False, False, False, False, False, False, False],
+            ),
+            (
+                3,
+                0,
+                [0, 0, 0, 1, 1, 1, 5, 6, 7],
+                pl.Int64,
+                [False, False, False, True, True, True, False, False, False],
+            ),
+            (
+                3,
+                "a",
+                ["a", "a", "a", "b", "b", "b", "c", "d", "e"],
+                pl.String,
+                [False, False, False, True, True, True, False, False, False],
             ),
         ],
         ids=[
-            "ignore_val_as_float",
-            "ignore_val_as_list",
-            "ignore_vals_not_present",
+            "float_ignore_as_scalar",
+            "float_ignore_as_list",
+            "float_ignore_vals_not_present",
+            "float_col_int_ignore_upcast",
+            "float_col_mixed_int_float_ignore",
+            "int_col_int_ignore",
+            "string_col_string_ignore",
         ],
     )
     def test_with_ignore_values(
-        self, threshold: int, ignore: float | list, data: list[float], expected: list[bool]
+        self, min_count: int, ignore: Any, data: list, col_dtype: pl.DataType, expected: list[bool]
     ) -> None:
-        """Test that null values in the middle of a flat line are not counted, but do not break the flat line."""
+        """Test that values in ignore_value are not flagged even when they form a flat line."""
+        df = self.tf.df.with_columns(pl.Series(data, dtype=col_dtype).alias("value_a"))
+        tf = self.tf.with_df(df)
+
+        check = FlatLineCheck(min_count, ignore_value=ignore)
+        result = check.apply(tf.df, tf.time_name, "value_a")
+        expected_series = pl.Series(expected)
+        assert_series_equal(result, expected_series)
+
+    @pytest.mark.parametrize(
+        "ignore,data,col_dtype",
+        [
+            ("bad", [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 5.0, 6.0, 7.0], pl.Float64),
+            (0.0, [0, 0, 0, 1, 1, 1, 5, 6, 7], pl.Int64),
+            (1, ["a", "a", "a", "b", "b", "b", "c", "d", "e"], pl.String),
+        ],
+        ids=[
+            "string_ignore_for_float_col",
+            "float_ignore_for_int_col",
+            "int_ignore_for_string_col",
+        ],
+    )
+    def test_with_bad_ignore_values(self, ignore: Any, data: list, col_dtype: pl.DataType) -> None:
+        """Test that incompatible ignore_value types raise TypeError."""
+        df = self.tf.df.with_columns(pl.Series(data, dtype=col_dtype).alias("value_a"))
+        tf = self.tf.with_df(df)
+
+        check = FlatLineCheck(3, ignore_value=ignore)
+        with pytest.raises(TypeError, match="incompatible with"):
+            check.apply(tf.df, tf.time_name, "value_a")
+
+    @pytest.mark.parametrize(
+        "tolerance,data,expected",
+        [
+            (
+                0.01,
+                [1.0, 1.005, 1.009, 1.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                [True, True, True, True, False, False, False, False, False],
+            ),
+            (
+                0.01,
+                [1.0, 1.011, 1.0, 1.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                [False, False, False, False, False, False, False, False, False],
+            ),
+            (
+                0.01,
+                [1.0, 1.01, 1.02, 5.0, 6.0, 7.0, 8.0, 8.0, 8.0],
+                [False, False, False, False, False, False, True, True, True],
+            ),
+            (
+                0.001,
+                [0.0, 0.0005, 0.0009, 0.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                [True, True, True, True, False, False, False, False, False],
+            ),
+        ],
+        ids=[
+            "within_tolerance_flagged",
+            "outside_tolerance_not_flagged",
+            "exact_boundary_flagged",
+            "small_tolerance",
+        ],
+    )
+    def test_tolerance(self, tolerance: float, data: list[float], expected: list[bool]) -> None:
+        """Test that tolerance allows near-equal consecutive values to be treated as equal."""
         df = self.tf.df.with_columns(pl.Series(data).alias("value_a"))
         tf = self.tf.with_df(df)
 
-        check = FlatLineCheck(threshold, ignore_values=ignore)
+        check = FlatLineCheck(3, tolerance=tolerance)
+        result = check.apply(tf.df, tf.time_name, "value_a")
+        expected_series = pl.Series(expected)
+        assert_series_equal(result, expected_series)
+
+    @pytest.mark.parametrize(
+        "tolerance,data,expected",
+        [
+            (
+                0.01,
+                [1.0, 1.005, None, 1.0, 1.005, 1.009, 9.0, 8.0, 7.0],
+                [False, False, False, True, True, True, False, False, False],
+            ),
+            (
+                0.01,
+                [None, 1.0, 1.005, 1.009, 5.0, 6.0, 7.0, 8.0, 9.0],
+                [False, True, True, True, False, False, False, False, False],
+            ),
+        ],
+        ids=[
+            "null_breaks_tolerance_flatline",
+            "null_at_start_with_tolerance",
+        ],
+    )
+    def test_tolerance_with_nulls(self, tolerance: float, data: list[float], expected: list[bool]) -> None:
+        """Test that null values correctly break flat line groups when tolerance is set."""
+        df = self.tf.df.with_columns(pl.Series(data).alias("value_a"))
+        tf = self.tf.with_df(df)
+
+        check = FlatLineCheck(3, tolerance=tolerance)
         result = check.apply(tf.df, tf.time_name, "value_a")
         expected_series = pl.Series(expected)
         assert_series_equal(result, expected_series)

--- a/tests/time_stream/test_qc.py
+++ b/tests/time_stream/test_qc.py
@@ -989,3 +989,101 @@ class TestFlatLineCheck:
         result = check.apply(tf.df, tf.time_name, "value_a")
         expected_series = pl.Series(expected)
         assert_series_equal(result, expected_series)
+
+    @pytest.mark.parametrize(
+        "min_count,data,expected",
+        [
+            (
+                2,
+                ["a", "b", "b", "b", "c", "d", "e", "f", "g"],
+                [False, True, True, True, False, False, False, False, False],
+            ),
+            (
+                2,
+                ["a", "a", "a", "a", "b", "c", "d", "e", "f"],
+                [True, True, True, True, False, False, False, False, False],
+            ),
+            (
+                3,
+                ["a", "b", "b", "b", "c", "d", "e", "f", "g"],
+                [False, True, True, True, False, False, False, False, False],
+            ),
+            (
+                4,
+                ["a", "b", "b", "b", "c", "d", "e", "f", "g"],
+                [False, False, False, False, False, False, False, False, False],
+            ),
+        ],
+        ids=[
+            "simple_flat_line",
+            "from_start",
+            "flatline_len_is_min_count",
+            "flat_line_below_min_count",
+        ],
+    )
+    def test_string_data_min_count(self, min_count: int, data: list[str], expected: list[bool]) -> None:
+        """Test that the flat line check works correctly with string column data."""
+        df = self.tf.df.with_columns(pl.Series(data, dtype=pl.String).alias("value_a"))
+        tf = self.tf.with_df(df)
+
+        check = FlatLineCheck(min_count)
+        result = check.apply(tf.df, tf.time_name, "value_a")
+        expected_series = pl.Series(expected)
+        assert_series_equal(result, expected_series)
+
+    @pytest.mark.parametrize(
+        "min_count,data,expected",
+        [
+            (
+                3,
+                ["a", "a", "a", None, "b", "c", "d", "e", "f"],
+                [True, True, True, False, False, False, False, False, False],
+            ),
+            (
+                3,
+                ["a", "a", "a", None, "a", "a", "a", "b", "c"],
+                [True, True, True, False, True, True, True, False, False],
+            ),
+            (
+                3,
+                [None, "a", "a", "a", "b", "c", "d", "e", "f"],
+                [False, True, True, True, False, False, False, False, False],
+            ),
+            (
+                3,
+                [None, None, None, "a", "a", "a", "b", "c", "d"],
+                [False, False, False, True, True, True, False, False, False],
+            ),
+            (
+                3,
+                [None, None, None, None, None, None, None, None, None],
+                [False, False, False, False, False, False, False, False, False],
+            ),
+        ],
+        ids=[
+            "null_breaks_flatline",
+            "two_flatlines_separated_by_null",
+            "null_at_start",
+            "multiple_nulls_at_start",
+            "all_nulls",
+        ],
+    )
+    def test_string_data_with_nulls(self, min_count: int, data: list[str | None], expected: list[bool]) -> None:
+        """Test that null values are handled correctly in string columns."""
+        df = self.tf.df.with_columns(pl.Series(data, dtype=pl.String).alias("value_a"))
+        tf = self.tf.with_df(df)
+
+        check = FlatLineCheck(min_count)
+        result = check.apply(tf.df, tf.time_name, "value_a")
+        expected_series = pl.Series(expected)
+        assert_series_equal(result, expected_series)
+
+    def test_string_data_with_tolerance_raises(self) -> None:
+        """Test that using tolerance with a string column raises an error."""
+        data = ["a", "a", "a", "b", "b", "b", "c", "d", "e"]
+        df = self.tf.df.with_columns(pl.Series(data, dtype=pl.String).alias("value_a"))
+        tf = self.tf.with_df(df)
+
+        check = FlatLineCheck(3, tolerance=0.1)
+        with pytest.raises(Exception):
+            check.apply(tf.df, tf.time_name, "value_a")


### PR DESCRIPTION
### `FlatLineCheck`
- Renamed `threshold` to `min_count` - thought it is a bit more understandable what the variable is for
- Added a `tolerance`  parameters - this let's users give a buffer around the values that it's checking for repeats from
- Add type validation for `ignore_value` - values are now cast to the column dtype before comparison, with a clear `TypeError` if incompatible.  Example of [0, 3.1] should now work as the integer "0" can be cast safely to float. 

### Docs
- Modified QC page to separate QC check examples into distinct headers to help separate them out a bit
- Added flatline check docs, with examples of using `ignore_value` and `threshold`