### PR TITLE
FPM-588: Autogenerate flag values

### DIFF
--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -416,14 +416,18 @@ class TimeFrame:
         tf.sort_time()
         return tf
 
-    def register_flag_system(self, name: str, flag_system: FlagSystemType) -> None:
+    def register_flag_system(self, name: str, flag_system: FlagSystemType = None) -> None:
         """Register a named flag system with the internal flag manager.
 
         Args:
             name: Short name for the flag system
             flag_system: The flag system to register, provided either as:
                             - a dict mapping of flag names to single-bit integer values, or;
-                            - a ``BitwiseFlag`` enum class, whose members are single-bit integers.
+                            - a ``BitwiseFlag`` enum class, whose members are single-bit integers, or;
+                            - a list of category name strings, from which bit values are auto-generated.
+                              The list is sorted before assigning values, so the same set of names always
+                              produces the same mapping. An empty list or ``None`` produces a single
+                              ``FLAGGED`` flag at value 1.
         """
         self._flag_manager.register_flag_system(name, flag_system)
 

--- a/src/time_stream/flag_manager.py
+++ b/src/time_stream/flag_manager.py
@@ -24,7 +24,7 @@ from time_stream.exceptions import (
     FlagSystemTypeError,
 )
 
-FlagSystemType = dict[str, int] | type[BitwiseFlag]
+FlagSystemType = dict[str, int] | type[BitwiseFlag] | list[str] | None
 
 
 @dataclass
@@ -115,14 +115,14 @@ class FlagManager:
         """Registered flag columns."""
         return self._flag_columns
 
-    def register_flag_system(self, flag_system_name: str, flag_system: FlagSystemType) -> None:
+    def register_flag_system(self, flag_system_name: str, flag_system: FlagSystemType = None) -> None:
         """Registers a flag system with the flag manager.  A flag system will contain flag values and their meanings.
 
         A flag system can be used to create flag columns that are specific to a particular type of flag.
         The flag system must contain valid bitwise values and their name. Using bitwise values
         allows for multiple flags to be set on a single value.
 
-        For example, if we had a quality_control flag system, we could define it as follows:
+        For example, if we had a quality_control flag system, we could define it as follows using a dict:
 
         > flag_system_name = "quality_control"
         > flag_dict = {
@@ -132,20 +132,56 @@ class FlagManager:
         > }
 
         The flag_dict itself can be passed to this method, or a BitwiseFlag object can be created from the dict:
+
         > flag_system = BitwiseFlag(flag_dict, name=flag_system_name)
+
+        Alternatively, a list of category names can be passed and bit values will be assigned automatically.
+        The list is sorted before assigning values, so the same set of names always produces the same mapping:
+
+        > flag_system = ["OUT_OF_RANGE", "SPIKE", "LOW_BATTERY"]
+
+        would produce a dict equivalent to:
+
+        > flag_dict = {
+        >     "LOW_BATTERY": 1,
+        >     "OUT_OF_RANGE": 2,
+        >     "SPIKE": 4,
+        > }
+
+        An empty list or ``None`` produces a default flag system with a single member at value 1:
+
+        > flag_dict = {
+        >     "FLAGGED": 1
+        > }
 
         Args:
             flag_system_name: The name of the new flag system.
-            flag_system: The flag system containing flag values and their meanings.
+            flag_system: The flag system containing flag values and their meanings. Defaults to ``None``.
 
         Raises:
-            FlagSystemTypeError: If the flag system is not a valid type.
+            DuplicateFlagSystemError: If a flag system with the same name is already registered.
+            FlagSystemTypeError: If the flag system is not a valid type, or the list contains duplicate names.
         """
         if flag_system_name in self._flag_systems:
             raise DuplicateFlagSystemError(f"Flag system '{flag_system_name}' already exists.")
 
-        if isinstance(flag_system, BitwiseMeta):
+        default_flag_dict = {"FLAGGED": 1}
+
+        if flag_system is None:
+            self._flag_systems[flag_system_name] = BitwiseFlag(flag_system_name, default_flag_dict)
+
+        elif isinstance(flag_system, BitwiseMeta):
             self._flag_systems[flag_system_name] = flag_system
+
+        elif isinstance(flag_system, list):
+            if len(set(flag_system)) != len(flag_system):
+                raise FlagSystemTypeError("Flag system list contains duplicate category names.")
+            if len(flag_system) == 0:
+                flag_dict = default_flag_dict
+            else:
+                sorted_categories = sorted(flag_system)
+                flag_dict = {name: 2**i for i, name in enumerate(sorted_categories)}
+            self._flag_systems[flag_system_name] = BitwiseFlag(flag_system_name, flag_dict)
 
         elif isinstance(flag_system, dict):
             self._flag_systems[flag_system_name] = BitwiseFlag(flag_system_name, flag_system)
@@ -153,7 +189,7 @@ class FlagManager:
         else:
             raise FlagSystemTypeError(
                 f"Unknown type of flag system: {type(flag_system)}. "
-                f"Expected dict[str, int] or a ``BitwiseFlag`` subclass."
+                f"Expected dict[str, int], list[str], or a ``BitwiseFlag`` subclass."
             )
 
     def get_flag_system(self, flag_system_name: str) -> type[BitwiseFlag]:

--- a/tests/time_stream/test_flag_manager.py
+++ b/tests/time_stream/test_flag_manager.py
@@ -15,6 +15,7 @@ from time_stream.exceptions import (
     DuplicateFlagSystemError,
     FlagSystemError,
     FlagSystemNotFoundError,
+    FlagSystemTypeError,
 )
 from time_stream.flag_manager import FlagColumn, FlagManager
 
@@ -42,6 +43,46 @@ class TestRegisterFlagSystem:
 
         with pytest.raises(DuplicateFlagSystemError):
             flag_manager.register_flag_system("quality_control", new_flag_system)
+
+    def test_add_valid_list_flag_system(self) -> None:
+        """Test adding a flag system from a list of category names."""
+        flag_manager = FlagManager()
+        flag_manager.register_flag_system("new_flags", ["FLAG_A", "FLAG_B", "FLAG_C"])
+
+        assert "new_flags" in flag_manager.flag_systems
+
+        # check the bit values were correctly assigned
+        flag_system = flag_manager.get_flag_system("new_flags")
+        values = sorted(flag_system.to_dict().values())
+        assert values == [1, 2, 4]
+
+    def test_list_flag_system_is_sorted(self) -> None:
+        """Test that unsorted list input produces the same flag system as sorted input."""
+        fm1 = FlagManager()
+        fm1.register_flag_system("flags", ["C", "A", "B"])
+        fm2 = FlagManager()
+        fm2.register_flag_system("flags", ["A", "B", "C"])
+        assert fm1.get_flag_system("flags") == fm2.get_flag_system("flags")
+
+    def test_empty_list_produces_default_flagged(self) -> None:
+        """Test that an empty list produces a default FLAGGED flag at value 1."""
+        flag_manager = FlagManager()
+        flag_manager.register_flag_system("default_flags", [])
+        flag_system = flag_manager.get_flag_system("default_flags")
+        assert flag_system.to_dict() == {"FLAGGED": 1}
+
+    def test_none_produces_default_flagged(self) -> None:
+        """Test that None produces a default FLAGGED flag at value 1."""
+        flag_manager = FlagManager()
+        flag_manager.register_flag_system("default_flags")
+        flag_system = flag_manager.get_flag_system("default_flags")
+        assert flag_system.to_dict() == {"FLAGGED": 1}
+
+    def test_duplicate_list_entries_raises_error(self) -> None:
+        """Test that duplicate names in the list raise FlagSystemTypeError."""
+        flag_manager = FlagManager()
+        with pytest.raises(FlagSystemTypeError):
+            flag_manager.register_flag_system("new_flags", ["FLAG_A", "FLAG_B", "FLAG_A"])
 
 
 class TestRegisterFlagColumn:


### PR DESCRIPTION
# Background
Previously, registering a flag system required supplying explicit power-of-2 integers for each category, e.g: 

`tf.register_flag_system("qc", {"OUT_OF_RANGE": 1, "SPIKE": 2, "LOW_BATTERY": 4})`                                                                                       

This PR allows a list of strings to be passed instead, with bit values assigned automatically:

`tf.register_flag_system("qc", ["OUT_OF_RANGE", "SPIKE", "LOW_BATTERY"])`

The list is sorted before values are assigned, ensuring the same set of names always produces the same mapping regardless of input order. Passing None (now the default) or an empty list produces a minimal flag system with a single FLAGGED member at value 1.

## Main changes                                
  - flag_manager.py - extended FlagSystemType and added list/None handling in register_flag_system
  - base.py - updated TimeFrame.register_flag_system signature and docstring to match
  - test_flag_manager.py - tests for list input, sort consistency, empty list default, None default, and duplicate name error

## Note

  - Documentation will be modified in another PR