### PR TITLE
FPM-942: Flag decoding

### DIFF
--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -416,14 +416,18 @@ class TimeFrame:
         tf.sort_time()
         return tf
 
-    def register_flag_system(self, name: str, flag_system: FlagSystemType) -> None:
+    def register_flag_system(self, name: str, flag_system: FlagSystemType = None) -> None:
         """Register a named flag system with the internal flag manager.
 
         Args:
             name: Short name for the flag system
             flag_system: The flag system to register, provided either as:
                             - a dict mapping of flag names to single-bit integer values, or;
-                            - a ``BitwiseFlag`` enum class, whose members are single-bit integers.
+                            - a ``BitwiseFlag`` enum class, whose members are single-bit integers, or;
+                            - a list of category name strings, from which bit values are auto-generated.
+                              The list is sorted before assigning values, so the same set of names always
+                              produces the same mapping. An empty list or ``None`` produces a single
+                              ``FLAGGED`` flag at value 1.
         """
         self._flag_manager.register_flag_system(name, flag_system)
 

--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -45,7 +45,7 @@ from time_stream.aggregation import (
 from time_stream.bitwise import BitwiseFlag
 from time_stream.calculations import calculate_min_max_envelope
 from time_stream.enums import ClosedInterval, DuplicateOption, RollingAlignment, TimeAnchor, ValidationErrorOptions
-from time_stream.exceptions import ColumnNotFoundError, MetadataError, TimeWindowError
+from time_stream.exceptions import ColumnNotFoundError, ColumnTypeError, MetadataError, TimeWindowError
 from time_stream.flag_manager import FlagColumn, FlagManager, FlagSystemType
 from time_stream.formatting import timeframe_repr
 from time_stream.infill import InfillMethod
@@ -521,6 +521,60 @@ class TimeFrame:
         """
         flag_column = self.get_flag_column(column_name)
         self._df = flag_column.remove_flag(self.df, flag_value, expr)
+
+    def decode_flag_column(self, flag_column_name: str) -> Self:
+        """Decode an integer flag column to a List(String) column of active flag names.
+
+        Replaces the column in-place (same name, dtype changes from integer to List(String)).
+        Each row contains the names of flags that are set, sorted by ascending bit value.
+        A value of 0 produces an empty list.
+
+        The column remains registered as a flag column. add_flag and remove_flag continue
+        to work transparently on the decoded column.
+
+        Args:
+            flag_column_name: Name of the registered integer flag column to decode.
+
+        Returns:
+            A new TimeFrame with the flag column replaced by a List(String) column.
+
+        Raises:
+            ColumnNotFoundError: If flag_column_name is not a registered flag column.
+            ColumnTypeError: If the flag column is not an integer dtype.
+        """
+        flag_column = self.get_flag_column(flag_column_name)
+        if not self.df[flag_column_name].dtype.is_integer():
+            raise ColumnTypeError(
+                f"Flag column '{flag_column_name}' must be an integer dtype, got '{self.df[flag_column_name].dtype}'."
+            )
+        tf = self.with_df(flag_column.decode(self.df))
+        tf._flag_manager.flag_columns[flag_column_name].is_decoded = True
+        return tf
+
+    def encode_flag_column(self, flag_column_name: str) -> Self:
+        """Encode a List(String) flag column back to a bitwise integer column.
+
+        Replaces the column in-place (same name, dtype changes from List(String) to integer).
+        Each flag name in the list contributes its bit value. An empty list produces 0.
+
+        Args:
+            flag_column_name: Name of the registered flag column containing List(String) data.
+
+        Returns:
+            A new TimeFrame with the flag column replaced by an integer column.
+
+        Raises:
+            ColumnNotFoundError: If flag_column_name is not a registered flag column.
+            ColumnTypeError: If the flag column is not a List(String) dtype.
+            BitwiseFlagUnknownError: If the column contains any flag name not in the flag system.
+        """
+        flag_column = self.get_flag_column(flag_column_name)
+        col_dtype = self.df[flag_column_name].dtype
+        if not (isinstance(col_dtype, pl.List) and col_dtype.inner == pl.String):
+            raise ColumnTypeError(f"Flag column '{flag_column_name}' must be List(String) dtype, got '{col_dtype}'.")
+        tf = self.with_df(flag_column.encode(self.df))
+        tf._flag_manager.flag_columns[flag_column_name].is_decoded = False
+        return tf
 
     def aggregate(
         self,

--- a/src/time_stream/flag_manager.py
+++ b/src/time_stream/flag_manager.py
@@ -24,7 +24,7 @@ from time_stream.exceptions import (
     FlagSystemTypeError,
 )
 
-FlagSystemType = dict[str, int] | type[BitwiseFlag]
+FlagSystemType = dict[str, int] | type[BitwiseFlag] | list[str] | None
 
 
 @dataclass
@@ -115,14 +115,14 @@ class FlagManager:
         """Registered flag columns."""
         return self._flag_columns
 
-    def register_flag_system(self, flag_system_name: str, flag_system: FlagSystemType) -> None:
+    def register_flag_system(self, flag_system_name: str, flag_system: FlagSystemType = None) -> None:
         """Registers a flag system with the flag manager.  A flag system will contain flag values and their meanings.
 
         A flag system can be used to create flag columns that are specific to a particular type of flag.
         The flag system must contain valid bitwise values and their name. Using bitwise values
         allows for multiple flags to be set on a single value.
 
-        For example, if we had a quality_control flag system, we could define it as follows:
+        For example, if we had a quality_control flag system, we could define it as follows using a dict:
 
         > flag_system_name = "quality_control"
         > flag_dict = {
@@ -132,20 +132,56 @@ class FlagManager:
         > }
 
         The flag_dict itself can be passed to this method, or a BitwiseFlag object can be created from the dict:
+
         > flag_system = BitwiseFlag(flag_dict, name=flag_system_name)
+
+        Alternatively, a list of category names can be passed and bit values will be assigned automatically.
+        The list is sorted before assigning values, so the same set of names always produces the same mapping:
+
+        > flag_system = ["OUT_OF_RANGE", "SPIKE", "LOW_BATTERY"]
+
+        would produce a dict equivalent to:
+
+        > flag_dict = {
+        >     "LOW_BATTERY": 1,
+        >     "OUT_OF_RANGE": 2,
+        >     "SPIKE": 4,
+        > }
+
+        An empty list or ``None`` produces a default flag system with a single member at value 1:
+
+        > flag_dict = {
+        >     "FLAGGED": 1
+        > }
 
         Args:
             flag_system_name: The name of the new flag system.
-            flag_system: The flag system containing flag values and their meanings.
+            flag_system: The flag system containing flag values and their meanings. Defaults to ``None``.
 
         Raises:
-            FlagSystemTypeError: If the flag system is not a valid type.
+            DuplicateFlagSystemError: If a flag system with the same name is already registered.
+            FlagSystemTypeError: If the flag system is not a valid type, or the list contains duplicate names.
         """
         if flag_system_name in self._flag_systems:
             raise DuplicateFlagSystemError(f"Flag system '{flag_system_name}' already exists.")
 
-        if isinstance(flag_system, BitwiseMeta):
+        default_flag_dict = {"FLAGGED": 1}
+
+        if flag_system is None:
+            self._flag_systems[flag_system_name] = BitwiseFlag(flag_system_name, default_flag_dict)
+
+        elif isinstance(flag_system, BitwiseMeta):
             self._flag_systems[flag_system_name] = flag_system
+
+        elif isinstance(flag_system, list):
+            if len(set(flag_system)) != len(flag_system):
+                raise FlagSystemTypeError("Flag system list contains duplicate category names.")
+            if len(flag_system) == 0:
+                flag_dict = default_flag_dict
+            else:
+                sorted_categories = sorted(flag_system)
+                flag_dict = {name: 2**i for i, name in enumerate(sorted_categories)}
+            self._flag_systems[flag_system_name] = BitwiseFlag(flag_system_name, flag_dict)
 
         elif isinstance(flag_system, dict):
             self._flag_systems[flag_system_name] = BitwiseFlag(flag_system_name, flag_system)
@@ -153,7 +189,7 @@ class FlagManager:
         else:
             raise FlagSystemTypeError(
                 f"Unknown type of flag system: {type(flag_system)}. "
-                f"Expected dict[str, int] or a ``BitwiseFlag`` subclass."
+                f"Expected dict[str, int], list[str], or a ``BitwiseFlag`` subclass."
             )
 
     def get_flag_system(self, flag_system_name: str) -> type[BitwiseFlag]:

--- a/src/time_stream/flag_manager.py
+++ b/src/time_stream/flag_manager.py
@@ -17,6 +17,7 @@ import polars as pl
 
 from time_stream.bitwise import BitwiseFlag, BitwiseMeta
 from time_stream.exceptions import (
+    BitwiseFlagUnknownError,
     ColumnNotFoundError,
     DuplicateFlagSystemError,
     FlagSystemError,
@@ -36,13 +37,69 @@ class FlagColumn:
     Attributes:
         name: Name of the flag column in the DataFrame.
         flag_system: The enum class that defines the available flags and their bit values.
+        is_decoded: Whether the column is currently in decoded List(String) form rather than integer form.
     """
 
     name: str
     flag_system: type[BitwiseFlag]
+    is_decoded: bool = False
+
+    def decode(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Replace the integer flag column with a List(String) column of active flag names.
+
+        Each row contains the names of flags that are set, sorted by ascending bit value. A value of 0 produces an
+        empty list.
+
+        Args:
+            df: The DataFrame containing the integer flag column.
+
+        Returns:
+            A new DataFrame with the flag column replaced by a List(String) column.
+        """
+
+        # Sort the flag system mapping into ascending bit value order
+        flag_map = sorted(self.flag_system.to_dict().items(), key=lambda kv: kv[1])
+
+        # Build expressions for decoding each flag value
+        exprs = [
+            pl.when((pl.col(self.name) & pl.lit(val)) != 0).then(pl.lit(name)).otherwise(pl.lit(None))
+            for name, val in flag_map
+        ]
+        return df.with_columns(pl.concat_list(exprs).list.drop_nulls().alias(self.name))
+
+    def encode(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Replace a List(String) flag column with a bitwise integer column.
+
+        Each flag name in the list contributes its bit value. An empty list produces 0.
+
+        Args:
+            df: The DataFrame containing the decoded List(String) flag column.
+
+        Returns:
+            A new DataFrame with the flag column replaced by an integer column.
+
+        Raises:
+            BitwiseFlagUnknownError: If any flag name in the column is not in the flag system.
+        """
+        flag_map = self.flag_system.to_dict()
+        present = set(df[self.name].explode().drop_nulls().unique().to_list())
+        unknown = present - flag_map.keys()
+        if unknown:
+            raise BitwiseFlagUnknownError(f"Unknown flag names in column '{self.name}': {sorted(unknown)}.")
+
+        exprs = [
+            pl.when(pl.col(self.name).list.contains(pl.lit(name)))
+            .then(pl.lit(val, dtype=pl.Int64))
+            .otherwise(pl.lit(0, dtype=pl.Int64))
+            for name, val in flag_map.items()
+        ]
+        return df.with_columns(pl.sum_horizontal(exprs).alias(self.name))
 
     def add_flag(self, df: pl.DataFrame, flag: int | str, expr: pl.Expr = pl.lit(True)) -> pl.DataFrame:
         """Adds a flag value to this FlagColumn using a bitwise OR operation.
+
+        If the column is currently decoded (List(String)), it is encoded first, the flag is applied,
+        and the result is decoded again.
 
         Args:
             df: The dataframe to add the flag value to.
@@ -54,12 +111,20 @@ class FlagColumn:
             A new DataFrame with the flag column updated.
         """
         flag = self.flag_system.get_single_flag(flag)
-        return df.with_columns(
+        if self.is_decoded:
+            df = self.encode(df)
+        df = df.with_columns(
             pl.when(expr).then(pl.col(self.name) | pl.lit(flag.value)).otherwise(pl.col(self.name)).alias(self.name)
         )
+        if self.is_decoded:
+            df = self.decode(df)
+        return df
 
     def remove_flag(self, df: pl.DataFrame, flag: int | str, expr: pl.Expr = pl.lit(True)) -> pl.DataFrame:
         """Remove a flag value from this FlagColumn using a bitwise AND operation.
+
+        If the column is currently decoded (List(String)), it is encoded first, the flag is removed,
+        and the result is decoded again.
 
         Args:
             df: The dataframe to remove the flag value from.
@@ -71,12 +136,20 @@ class FlagColumn:
             A new DataFrame with the flag column updated.
         """
         flag = self.flag_system.get_single_flag(flag)
-        return df.with_columns(
+        if self.is_decoded:
+            df = self.encode(df)
+        df = df.with_columns(
             pl.when(expr).then(pl.col(self.name) & ~pl.lit(flag.value)).otherwise(pl.col(self.name)).alias(self.name)
         )
+        if self.is_decoded:
+            df = self.decode(df)
+        return df
 
     def __eq__(self, other: object) -> bool:
         """Check if two FlagColumn instances are equal.
+
+        Compares name and flag_system only. is_decoded is runtime state and is excluded
+        from the comparison.
 
         Args:
             other: The object to compare.
@@ -246,6 +319,7 @@ class FlagManager:
         # register flag columns in the new copy with their associated system names
         for name, flag_column in self._flag_columns.items():
             out.register_flag_column(name, flag_column.flag_system.system_name())
+            out.flag_columns[name].is_decoded = flag_column.is_decoded
 
         return out
 

--- a/tests/time_stream/test_flag_manager.py
+++ b/tests/time_stream/test_flag_manager.py
@@ -15,6 +15,7 @@ from time_stream.exceptions import (
     DuplicateFlagSystemError,
     FlagSystemError,
     FlagSystemNotFoundError,
+    FlagSystemTypeError,
 )
 from time_stream.flag_manager import FlagColumn, FlagManager
 
@@ -42,6 +43,46 @@ class TestRegisterFlagSystem:
 
         with pytest.raises(DuplicateFlagSystemError):
             flag_manager.register_flag_system("quality_control", new_flag_system)
+
+    def test_add_valid_list_flag_system(self) -> None:
+        """Test adding a flag system from a list of category names."""
+        flag_manager = FlagManager()
+        flag_manager.register_flag_system("new_flags", ["FLAG_A", "FLAG_B", "FLAG_C"])
+
+        assert "new_flags" in flag_manager.flag_systems
+
+        # check the bit values were correctly assigned
+        flag_system = flag_manager.get_flag_system("new_flags")
+        values = sorted(flag_system.to_dict().values())
+        assert values == [1, 2, 4]
+
+    def test_list_flag_system_is_sorted(self) -> None:
+        """Test that unsorted list input produces the same flag system as sorted input."""
+        fm1 = FlagManager()
+        fm1.register_flag_system("flags", ["C", "A", "B"])
+        fm2 = FlagManager()
+        fm2.register_flag_system("flags", ["A", "B", "C"])
+        assert fm1.get_flag_system("flags") == fm2.get_flag_system("flags")
+
+    def test_empty_list_produces_default_flagged(self) -> None:
+        """Test that an empty list produces a default FLAGGED flag at value 1."""
+        flag_manager = FlagManager()
+        flag_manager.register_flag_system("default_flags", [])
+        flag_system = flag_manager.get_flag_system("default_flags")
+        assert flag_system.to_dict() == {"FLAGGED": 1}
+
+    def test_none_produces_default_flagged(self) -> None:
+        """Test that None produces a default FLAGGED flag at value 1."""
+        flag_manager = FlagManager()
+        flag_manager.register_flag_system("default_flags")
+        flag_system = flag_manager.get_flag_system("default_flags")
+        assert flag_system.to_dict() == {"FLAGGED": 1}
+
+    def test_duplicate_list_entries_raises_error(self) -> None:
+        """Test that duplicate names in the list raise FlagSystemTypeError."""
+        flag_manager = FlagManager()
+        with pytest.raises(FlagSystemTypeError):
+            flag_manager.register_flag_system("new_flags", ["FLAG_A", "FLAG_B", "FLAG_A"])
 
 
 class TestRegisterFlagColumn:

--- a/tests/time_stream/test_flag_manager.py
+++ b/tests/time_stream/test_flag_manager.py
@@ -295,6 +295,17 @@ class TestAddFlag:
 
         assert_series_equal(result, expected)
 
+    def test_add_flag_on_decoded_column(self) -> None:
+        """Test that add_flag on a decoded column leaves the column in List(String) with the flag added."""
+        tf = self.setup_tf()
+        tf_decoded = tf.decode_flag_column("flag_col_1")
+
+        tf_decoded.add_flag("flag_col_1", "FLAG_A")
+
+        result = tf_decoded.df["flag_col_1"]
+        assert result.dtype == pl.List(pl.String)
+        assert result.to_list() == [["FLAG_A"], ["FLAG_A"], ["FLAG_A"]]
+
 
 class TestRemoveFlag:
     @staticmethod
@@ -374,6 +385,17 @@ class TestRemoveFlag:
 
         with pytest.raises(ColumnNotFoundError):
             tf.add_flag("value", 1)
+
+    def test_remove_flag_on_decoded_column(self) -> None:
+        """Test that remove_flag on a decoded column leaves the column in List(String) with the flag removed."""
+        tf = self.setup_tf()
+        tf_decoded = tf.decode_flag_column("flag_col_1")
+
+        tf_decoded.remove_flag("flag_col_1", "FLAG_A")
+
+        result = tf_decoded.df["flag_col_1"]
+        assert result.dtype == pl.List(pl.String)
+        assert result.to_list() == [[], ["FLAG_B"], ["FLAG_B", "FLAG_C"]]
 
 
 class TestEqualityFlagManager:
@@ -549,3 +571,133 @@ class TestEqualityFlagColumn:
         flag_system1, flag_system2, flag_column_original = self.setup_flag_systems()
 
         assert flag_column_original != non_fs
+
+
+class TestDecodeFlagColumn:
+    @staticmethod
+    def setup_tf() -> TimeFrame:
+        tf = TimeFrame(
+            pl.DataFrame(
+                {
+                    "time": [datetime(2025, 1, 1), datetime(2025, 1, 2), datetime(2025, 1, 3), datetime(2025, 1, 4)],
+                    "value": [1, 2, 3, 4],
+                    "flag_col_1": [0, 1, 5, 7],
+                }
+            ),
+            "time",
+        ).with_flag_system("system1", {"FLAG_A": 1, "FLAG_B": 2, "FLAG_C": 4})
+        tf.register_flag_column("flag_col_1", "system1")
+        return tf
+
+    def test_output_dtype_is_list_string(self) -> None:
+        """Test that the decoded column has dtype List(String)."""
+        tf = self.setup_tf()
+        tf_decoded = tf.decode_flag_column("flag_col_1")
+        assert tf_decoded.df["flag_col_1"].dtype == pl.List(pl.String)
+
+    def test_same_column_name_after_decode(self) -> None:
+        """Test that the column name is preserved after decoding."""
+        tf = self.setup_tf()
+        tf_decoded = tf.decode_flag_column("flag_col_1")
+        assert "flag_col_1" in tf_decoded.df.columns
+
+    @pytest.mark.parametrize(
+        "row, expected",
+        [
+            (0, []),
+            (1, ["FLAG_A"]),
+            (2, ["FLAG_A", "FLAG_C"]),
+            (3, ["FLAG_A", "FLAG_B", "FLAG_C"]),
+        ],
+        ids=["zero", "single_flag", "two_flags", "all_flags_ascending_order"],
+    )
+    def test_integer_decodes_to_flag_names(self, row: int, expected: list[str]) -> None:
+        """Test that integer values decode to the correct flag name lists in ascending bit-value order."""
+        tf = self.setup_tf()
+        tf_decoded = tf.decode_flag_column("flag_col_1")
+        assert tf_decoded.df["flag_col_1"].to_list()[row] == expected
+        assert tf_decoded.get_flag_column("flag_col_1").is_decoded is True
+
+    def test_returns_new_timeframe(self) -> None:
+        """Test that decode_flag_column returns a new TimeFrame (original unchanged)."""
+        tf = self.setup_tf()
+        tf_decoded = tf.decode_flag_column("flag_col_1")
+        assert tf.get_flag_column("flag_col_1").is_decoded is False
+        assert tf_decoded is not tf
+
+    def test_unregistered_column_raises_column_not_found_error(self) -> None:
+        """Test that decoding an unregistered column raises ColumnNotFoundError."""
+        tf = self.setup_tf()
+        with pytest.raises(ColumnNotFoundError):
+            tf.decode_flag_column("value")
+
+
+class TestEncodeFlagColumn:
+    @staticmethod
+    def setup_tf() -> TimeFrame:
+        tf = TestDecodeFlagColumn.setup_tf()
+        return tf.decode_flag_column("flag_col_1")
+
+    def test_output_dtype_is_int64(self) -> None:
+        """Test that the encoded column has dtype Int64."""
+        tf_decoded = self.setup_tf()
+        tf_encoded = tf_decoded.encode_flag_column("flag_col_1")
+        assert tf_encoded.df["flag_col_1"].dtype == pl.Int64
+
+    def test_same_column_name_after_encode(self) -> None:
+        """Test that the column name is preserved after encoding."""
+        tf_decoded = self.setup_tf()
+        tf_encoded = tf_decoded.encode_flag_column("flag_col_1")
+        assert "flag_col_1" in tf_encoded.df.columns
+
+    @pytest.mark.parametrize(
+        "row, expected",
+        [
+            (0, 0),
+            (1, 1),
+            (2, 5),
+            (3, 7),
+        ],
+        ids=["empty_list", "single_flag", "two_flags", "all_flags"],
+    )
+    def test_flag_names_encode_to_integer(self, row: int, expected: int) -> None:
+        """Test that flag name lists encode to the correct bitwise integer values."""
+        tf_decoded = self.setup_tf()
+        tf_encoded = tf_decoded.encode_flag_column("flag_col_1")
+        assert tf_encoded.df["flag_col_1"].to_list()[row] == expected
+        assert tf_encoded.get_flag_column("flag_col_1").is_decoded is False
+
+    def test_returns_new_timeframe(self) -> None:
+        """Test that encode_flag_column returns a new TimeFrame (original unchanged)."""
+        tf_decoded = self.setup_tf()
+        tf_encoded = tf_decoded.encode_flag_column("flag_col_1")
+        assert tf_decoded.get_flag_column("flag_col_1").is_decoded is True
+        assert tf_encoded is not tf_decoded
+
+    def test_column_remains_registered(self) -> None:
+        """Test that the column is still registered as a flag column after encoding."""
+        tf_decoded = self.setup_tf()
+        tf_encoded = tf_decoded.encode_flag_column("flag_col_1")
+        assert tf_encoded.get_flag_column("flag_col_1") is not None
+
+    def test_unregistered_column_raises_column_not_found_error(self) -> None:
+        """Test that encoding an unregistered column raises ColumnNotFoundError."""
+        tf_decoded = self.setup_tf()
+        with pytest.raises(ColumnNotFoundError):
+            tf_decoded.encode_flag_column("value")
+
+    def test_unknown_flag_name_raises_error(self) -> None:
+        """Test that encoding a column containing an unknown flag name raises BitwiseFlagUnknownError."""
+        tf = TestDecodeFlagColumn.setup_tf()
+        df_with_unknown = tf.df.with_columns(pl.Series("flag_col_1", [["FLAG_A", "UNKNOWN"], [], [], []]))
+        tf_manual = tf.with_df(df_with_unknown)
+        tf_manual._flag_manager.flag_columns["flag_col_1"].is_decoded = True
+        with pytest.raises(BitwiseFlagUnknownError):
+            tf_manual.encode_flag_column("flag_col_1")
+
+    def test_decode_then_encode_produces_original_values(self) -> None:
+        """Test that decode followed by encode produces the original integer values."""
+        tf = TestDecodeFlagColumn.setup_tf()
+        original = tf.df["flag_col_1"].clone()
+        tf_roundtrip = tf.decode_flag_column("flag_col_1").encode_flag_column("flag_col_1")
+        assert_series_equal(tf_roundtrip.df["flag_col_1"], original)


### PR DESCRIPTION
# Background

Previously, flag columns store bitwise integers, but there is no way to recover human-readable flag names. This PR adds a decoding (and encoding) ability.

## Main changes
`FlagColumn` (flag_manager.py)
  - Added `is_decoded: bool = False` to keep the state of where the column is decoded or not. 
  - Added `decode(df)` - converts bit integer column to List(String) of flag names in ascending bit-value order. Flag value of 0 produces []
  - Added `encode(df)` - converts List(String) back to the bit-value.  
  - `add_flag` and `remove_flag` take into account the `is_decoded` state.  If the column is decoded, they do a round rtip of encode -> add/remove flag -> decode

`TimeFrame` (base.py)                                                                                                                                                                                                      
  - `decode_flag_column` - returns new TimeFrame with the integer flag column replaced by List(String)
  - `encode_flag_column` - returns new TimeFrame with the List(String) column replaced by it's equivalent bit integer values


## Notes
- Documentation to be addressed in future PR

## Usage

```
# Set up a TimeFrame with some pre-existing flag values
tf = TimeFrame(
    pl.DataFrame({
        "time": [datetime(2025, 1, 1), datetime(2025, 1, 2), datetime(2025, 1, 3), datetime(2025, 1, 4)],
        "value": [10.0, 20.0, 30.0, 40.0],
        "qc_flags": [0, 1, 5, 7],
    }),
    "time",
).with_flag_system("qc", {"SPIKE": 1, "OUT_OF_RANGE": 2, "LOW_BATTERY": 4})

tf.register_flag_column("qc_flags", "qc")

> tf.df["qc_flags"]
> [0, 1, 5, 7]

tf_decoded = tf.decode_flag_column("qc_flags")

> tf_decoded.df["qc_flags"]
> [
>	[],
>	["SPIKE"],
>	["SPIKE", "LOW_BATTERY"],
>	["SPIKE", "OUT_OF_RANGE", "LOW_BATTERY"],
> ]

# Add flag works on a decoded column
tf_decoded.add_flag("qc_flags", "OUT_OF_RANGE", pl.col("value") < 11)

> tf_decoded.df["qc_flags"]
> [
>	["OUT_OF_RANGE"],
>	["SPIKE"],
>	["SPIKE", "LOW_BATTERY"],
>	["SPIKE", "OUT_OF_RANGE", "LOW_BATTERY"],
> ]

# Re-encode
tf_encoded = tf_decoded.encode_flag_column("qc_flags")

> tf_encoded .df["qc_flags"]
> [2, 1, 5, 7]
```