### PR TITLE
FPM-587 - Flag qc / infill results

### DIFF
--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -864,7 +864,7 @@ class TimeFrame:
         check: str | Type[QCCheck] | QCCheck,
         column_name: str,
         observation_interval: tuple[datetime, datetime | None] | None = None,
-        into: str | bool = False,
+        flag_params: tuple[str, str | int] | None = None,
         **kwargs,
     ) -> "TimeFrame | pl.Series":
         """Apply a quality control check to the TimeFrame.
@@ -873,8 +873,9 @@ class TimeFrame:
             check: The QC check to apply.
             column_name: The column to perform the check on.
             observation_interval: Optional time interval to limit the check to.
-            into: Whether to add the result of the QC to the TimeFrame dataframe (True | string name of column to add),
-                  or just return a boolean Series of the QC result (False).
+            flag_params: Tuple of (flag column name [str], flag value [str | int].
+                            If provided, add given flag value to the flag column where the QC check returns ``True``.
+                            If not provided, the result of the QC check is returned as a boolean series.
             **kwargs: Parameters specific to the check type.
 
         Returns:
@@ -897,33 +898,23 @@ class TimeFrame:
         check_instance = QCCheck.get(check, **kwargs)
         qc_result = check_instance.apply(self.df, self.time_name, column_name, observation_interval)
 
-        # Return the boolean series, if requested
-        if not into:
+        if not flag_params:
+            # Return the boolean series, if requested
             return qc_result
-
-        # Determine the name of the column for the QC result
-        if isinstance(into, str):
-            qc_result_col_name = into
         else:
-            qc_result_col_name = f"__qc__{column_name}__{check_instance.name}"
-
-        if qc_result_col_name in self.df.columns:
-            # Auto-suffix the column name to avoid accidental overwrite
-            col_suffix = 1
-            while f"{qc_result_col_name}__{col_suffix}" in self.df.columns:
-                col_suffix += 1
-            qc_result_col_name = f"{qc_result_col_name}__{col_suffix}"
-
-        # Create a copy of the current TimeFrame, and update the dataframe with the QC result
-        new_df = self.df.with_columns(pl.Series(qc_result_col_name, qc_result))
-        return self.with_df(new_df)
+            # Otherwise, create a copy of the current TimeFrame, and update the dataframe with the QC result
+            flag_column_name, flag_value = flag_params
+            tf_result = self.copy()
+            tf_result.add_flag(flag_column_name, flag_value, qc_result)
+            return tf_result
 
     def infill(
         self,
         infill_method: str | Type[InfillMethod] | InfillMethod,
         column_name: str,
-        observation_interval: tuple[datetime, datetime | None] | None = None,
         max_gap_size: int | None = None,
+        observation_interval: tuple[datetime, datetime | None] | None = None,
+        flag_params: tuple[str, str | int] | None = None,
         **kwargs,
     ) -> TimeFrame:
         """Apply an infilling method to a column in the TimeFrame to fill in missing data.
@@ -931,9 +922,12 @@ class TimeFrame:
         Args:
             infill_method: The method to use for infilling
             column_name: The column to infill
-            observation_interval: Optional time interval to limit the check to.
             max_gap_size: The maximum size of consecutive null gaps that should be filled. Any gap larger than this
                           will not be infilled and will remain as null.
+            observation_interval: Optional time interval to limit the check to.
+            flag_params: Tuple of (flag column name [str], flag value [str | int].
+                            If provided, add given flag value to the flag column on rows that were infilled.
+                            If not provided, no flags added.
             **kwargs: Parameters specific to the infill method.
 
         Returns:
@@ -945,9 +939,23 @@ class TimeFrame:
             self.df, self.time_name, self.periodicity, column_name, observation_interval, max_gap_size
         )
 
-        # Create result TimeFrame
         # Create a copy of the current TimeFrame, and update the dataframe with the infilled data
-        return self.with_df(infill_result)
+        tf_result = self.with_df(infill_result)
+
+        if flag_params:
+            # Add flag where we have infilled data
+            flag_column_name, flag_value = flag_params
+
+            before = self.df[column_name]
+            after = tf_result.df[column_name]
+
+            before_is_null = before.is_null() | before.is_nan()
+            after_is_null = after.is_null() | after.is_nan()
+
+            mask = before_is_null.ne(after_is_null)
+            tf_result.add_flag(flag_column_name, flag_value, mask)
+
+        return tf_result
 
     def select(
         self,

--- a/src/time_stream/examples/examples_quality_control.py
+++ b/src/time_stream/examples/examples_quality_control.py
@@ -17,6 +17,7 @@ def create_simple_time_series() -> ts.TimeFrame:
     )
 
     tf = ts.TimeFrame(df=df, time_name="timestamp")
+    tf.register_flag_system("qc", {"FLAGGED": 1})
 
     return tf
 
@@ -27,8 +28,9 @@ def comparison_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_2]
+    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "comparison", "temperature", compare_to=50, operator=">=", into=True
+        "comparison", "temperature", compare_to=50, operator=">=", flag_params=("flag_temperature", "FLAGGED")
     )
     # [end_block_2]
     print(tf.df)
@@ -42,8 +44,10 @@ def comparison_qc_3() -> None:
 
     # [start_block_4]
     error_codes = [991, 992, 993, 994, 995]
+    tf.init_flag_column("qc", "flag_sensor_codes")
     tf = tf.qc_check(
-        "comparison", "sensor_codes", compare_to=error_codes, operator="is_in", into=True
+        "comparison", "sensor_codes", compare_to=error_codes, operator="is_in",
+        flag_params=("flag_sensor_codes", "FLAGGED")
     )
     # [end_block_4]
     print(tf.df)
@@ -55,6 +59,7 @@ def range_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_5]
+    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
         "range",
         "temperature",
@@ -62,7 +67,7 @@ def range_qc_1() -> None:
         max_value=50,
         closed="none",  # Range is not inclusive of min and max value
         within=False,  # Flag values outside of this range
-        into=True,
+        flag_params=("flag_temperature", "FLAGGED"),
     )
     # [end_block_5]
     print(tf.df)
@@ -74,8 +79,9 @@ def spike_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_7]
+    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "spike", "temperature", threshold=10.0, into=True
+        "spike", "temperature", threshold=10.0, flag_params=("flag_temperature", "FLAGGED")
     )
     # [end_block_7]
     print(tf.df)
@@ -88,12 +94,13 @@ def time_range_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_9]
+    tf.init_flag_column("qc", "flag_precipitation")
     tf = tf.qc_check(
         "time_range",
         "precipitation",
         min_value=time(1, 0),
         max_value=time(3, 0),
-        into=True
+        flag_params=("flag_precipitation", "FLAGGED")
     )
     # [end_block_9]
     print(tf.df)
@@ -105,12 +112,13 @@ def time_range_qc_2() -> None:
         tf = create_simple_time_series()
 
     # [start_block_10]
+    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
         "time_range",
         "temperature",
         min_value=datetime(2023, 1, 1, 3, 30),
         max_value=datetime(2023, 1, 1, 9, 30),
-        into=True,
+        flag_params=("flag_temperature", "FLAGGED"),
     )
     # [end_block_10]
     print(tf.df)
@@ -120,7 +128,9 @@ def create_flat_line_time_series() -> ts.TimeFrame:
     dates = [datetime(2023, 1, 1) + timedelta(hours=i) for i in range(10)]
     temperature = [18.0, 20.0, 20.0, 20.0, 20.0, 22.0, 21.0, 0.0, 0.0, 0.0]
     df = pl.DataFrame({"timestamp": dates, "temperature": temperature})
-    return ts.TimeFrame(df=df, time_name="timestamp")
+    tf = ts.TimeFrame(df=df, time_name="timestamp")
+    tf.register_flag_system("qc", {"FLAGGED": 1})
+    return tf
 
 
 def create_near_flat_line_time_series() -> ts.TimeFrame:
@@ -128,7 +138,9 @@ def create_near_flat_line_time_series() -> ts.TimeFrame:
     # Values drift slightly around 20, then jump to 22 and drift slightly around 21
     temperature = [18.0, 20.0, 20.005, 20.001, 19.991, 22.0, 20.99, 21.003, 21.009, 20.997]
     df = pl.DataFrame({"timestamp": dates, "temperature": temperature})
-    return ts.TimeFrame(df=df, time_name="timestamp")
+    tf = ts.TimeFrame(df=df, time_name="timestamp")
+    tf.register_flag_system("qc", {"FLAGGED": 1})
+    return tf
 
 
 def flat_line_qc_1() -> None:
@@ -137,8 +149,9 @@ def flat_line_qc_1() -> None:
         tf = create_flat_line_time_series()
 
     # [start_block_11]
+    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "flat_line", "temperature", min_count=3, into=True
+        "flat_line", "temperature", min_count=3, flag_params=("flag_temperature", "FLAGGED")
     )
     # [end_block_11]
     print(tf.df)
@@ -151,8 +164,9 @@ def flat_line_qc_2() -> None:
         tf = create_flat_line_time_series()
 
     # [start_block_12]
+    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "flat_line", "temperature", min_count=3, ignore_value=0.0, into=True
+        "flat_line", "temperature", min_count=3, ignore_value=0.0, flag_params=("flag_temperature", "FLAGGED")
     )
     # [end_block_12]
     print(tf.df)
@@ -165,8 +179,9 @@ def flat_line_qc_3() -> None:
         tf = create_near_flat_line_time_series()
 
     # [start_block_13]
+    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "flat_line", "temperature", min_count=3, tolerance=0.1, into=True
+        "flat_line", "temperature", min_count=3, tolerance=0.1, flag_params=("flag_temperature", "FLAGGED")
     )
     # [end_block_13]
     print(tf.df)

--- a/tests/time_stream/test_base.py
+++ b/tests/time_stream/test_base.py
@@ -1026,3 +1026,145 @@ class TestFilterByFlag:
         tf = self.setup_bitwise_tf()
         with pytest.raises(ColumnNotFoundError):
             tf.filter_by_flag("nonexistent_col", "FLAG_A")
+
+
+class TestQCCheckWithFlagParams:
+    """Tests for TimeFrame.qc_check() with the flag_params parameter."""
+
+    @staticmethod
+    def setup_tf() -> TimeFrame:
+        """Set up a TimeFrame with a bitwise flag column."""
+        df = pl.DataFrame(
+            {
+                "time": [datetime(2024, 1, i) for i in range(1, 6)],
+                "value": [5.0, 15.0, 3.0, 20.0, 8.0],
+            }
+        )
+        tf = TimeFrame(df=df, time_name="time")
+        tf.register_flag_system("flags", {"FLAG_A": 1, "FLAG_B": 2})
+        tf.init_flag_column("flags", "flag_col")
+        return tf
+
+    def test_no_flag_params_returns_series(self) -> None:
+        """Without flag_params, qc_check returns the expected boolean Series."""
+        tf = self.setup_tf()
+        result = tf.qc_check("range", "value", min_value=0.0, max_value=10.0, within=False)
+        expected = pl.Series([False, True, False, True, False])
+        assert_series_equal(result, expected, check_names=False)
+
+    def test_with_bitwise_flag(self) -> None:
+        """With flag_params, flag is set on rows where the QC check fails."""
+        tf = self.setup_tf()
+        result = tf.qc_check(
+            "range", "value", flag_params=("flag_col", "FLAG_A"), min_value=0.0, max_value=10.0, within=False
+        )
+        expected = pl.Series("flag_col", [0, 1, 0, 1, 0], dtype=pl.Int64)
+        assert_series_equal(result.df["flag_col"], expected)
+
+    def test_original_tf_not_modified(self) -> None:
+        """qc_check with flag_params does not modify the original TimeFrame."""
+        tf = self.setup_tf()
+        tf.qc_check("range", "value", flag_params=("flag_col", "FLAG_A"), min_value=0.0, max_value=10.0, within=False)
+        expected = pl.Series("flag_col", [0, 0, 0, 0, 0], dtype=pl.Int64)
+        assert_series_equal(tf.df["flag_col"], expected)
+
+    def test_unregistered_flag_column_raises(self) -> None:
+        """An unregistered flag column name raises ColumnNotFoundError."""
+        tf = self.setup_tf()
+        with pytest.raises(ColumnNotFoundError):
+            tf.qc_check(
+                "range", "value", flag_params=("nonexistent_col", "FLAG_A"), min_value=0.0, max_value=10.0, within=False
+            )
+
+    def test_with_categorical_flag(self) -> None:
+        """Flag is set correctly when using a categorical flag column."""
+        df = pl.DataFrame(
+            {
+                "time": [datetime(2024, 1, i) for i in range(1, 4)],
+                "value": [5.0, 15.0, 3.0],
+            }
+        )
+        tf = TimeFrame(df=df, time_name="time")
+        tf.register_flag_system("flags", {"FLAG_A": 0, "FLAG_B": 1}, flag_type="categorical")
+        tf.init_flag_column("flags", "flag_col")
+        result = tf.qc_check(
+            "range", "value", flag_params=("flag_col", "FLAG_B"), min_value=0.0, max_value=10.0, within=False
+        )
+        expected = pl.Series("flag_col", [None, 1, None], dtype=pl.Int32)
+        assert_series_equal(result.df["flag_col"], expected)
+
+
+class TestInfillWithFlagParams:
+    """Tests for TimeFrame.infill() with the flag_params parameter."""
+
+    @staticmethod
+    def setup_tf() -> TimeFrame:
+        """Set up a TimeFrame with nulls and a bitwise flag column."""
+        df = pl.DataFrame(
+            {
+                "time": [datetime(2024, 1, i) for i in range(1, 6)],
+                "value": [1.0, None, 3.0, None, 5.0],
+            }
+        )
+        tf = TimeFrame(df=df, time_name="time", resolution=Period.of_days(1), periodicity=Period.of_days(1))
+        tf.register_flag_system("flags", {"FLAG_A": 1, "FLAG_B": 2})
+        tf.init_flag_column("flags", "flag_col")
+        return tf
+
+    def test_without_flag_params_no_flags_set(self) -> None:
+        """Without flag_params, infill returns a TimeFrame with no flags set."""
+        tf = self.setup_tf()
+        result = tf.infill("linear", "value")
+        expected = pl.Series("flag_col", [0, 0, 0, 0, 0], dtype=pl.Int64)
+        assert_series_equal(result.df["flag_col"], expected)
+
+    def test_bitwise_flag_set_on_infilled_rows(self) -> None:
+        """Flag is set only on rows that were null before infilling."""
+        tf = self.setup_tf()
+        result = tf.infill("linear", "value", flag_params=("flag_col", "FLAG_A"))
+        expected = pl.Series("flag_col", [0, 1, 0, 1, 0], dtype=pl.Int64)
+        assert_series_equal(result.df["flag_col"], expected)
+
+    def test_with_max_gap_size_flags_only_filled_gaps(self) -> None:
+        """With max_gap_size, flags are set only on gaps that were actually filled."""
+        df = pl.DataFrame(
+            {
+                "time": [datetime(2024, 1, i) for i in range(1, 8)],
+                "value": [1.0, None, 3.0, None, None, None, 7.0],
+            }
+        )
+        tf = TimeFrame(df=df, time_name="time", resolution=Period.of_days(1), periodicity=Period.of_days(1))
+        tf.register_flag_system("flags", {"FLAG_A": 1, "FLAG_B": 2})
+        tf.init_flag_column("flags", "flag_col")
+        # max_gap_size=1: only the single-row gap (index 1) gets filled and flagged
+        result = tf.infill("linear", "value", max_gap_size=1, flag_params=("flag_col", "FLAG_A"))
+        expected = pl.Series("flag_col", [0, 1, 0, 0, 0, 0, 0], dtype=pl.Int64)
+        assert_series_equal(result.df["flag_col"], expected)
+
+    def test_nothing_to_infill_flags_unchanged(self) -> None:
+        """When there are no nulls, flags remain all zero."""
+        df = pl.DataFrame(
+            {
+                "time": [datetime(2024, 1, i) for i in range(1, 4)],
+                "value": [1.0, 2.0, 3.0],
+            }
+        )
+        tf = TimeFrame(df=df, time_name="time", resolution=Period.of_days(1), periodicity=Period.of_days(1))
+        tf.register_flag_system("flags", {"FLAG_A": 1, "FLAG_B": 2})
+        tf.init_flag_column("flags", "flag_col")
+        result = tf.infill("linear", "value", flag_params=("flag_col", "FLAG_A"))
+        expected = pl.Series("flag_col", [0, 0, 0], dtype=pl.Int64)
+        assert_series_equal(result.df["flag_col"], expected)
+
+    def test_unregistered_flag_column_raises(self) -> None:
+        """An unregistered flag column name raises ColumnNotFoundError."""
+        tf = self.setup_tf()
+        with pytest.raises(ColumnNotFoundError):
+            tf.infill("linear", "value", flag_params=("nonexistent_col", "FLAG_A"))
+
+    def test_original_tf_not_modified(self) -> None:
+        """infill with flag_params does not modify the original TimeFrame."""
+        tf = self.setup_tf()
+        tf.infill("linear", "value", flag_params=("flag_col", "FLAG_A"))
+        expected = pl.Series("flag_col", [0, 0, 0, 0, 0], dtype=pl.Int64)
+        assert_series_equal(tf.df["flag_col"], expected)


### PR DESCRIPTION
# Overview

Previously, the QC and infill methods didn't integrate directly with the flagging systems.  This PR integrates the flag system into qc_check() and infill() so users can automatically flag rows based on QC failures or infill application.

## Main changes

- TimeFrame.qc_check() - removes the `into` parameter; replaces with `flag_params`. Without flag_params, returns a boolean Series (as before when `into` was False). When `flag_params` are provided, sets the given flag value to the given flag column on all rows that failed the QC check, returns a new TimeFrame
- TimeFrame.infill() - similar to qc_check, adds `flag_params`. When provided, sets the given flag value to the given flag column on rows that were null before infilling and non-null after.

## Notes
Documentation will get wrapped up in FPM-283. 
