### PR TITLE
FPM-283 - Update flagging documentation

### DIFF
--- a/docs/source/api/_api/time_stream.TimeFrame.decode_flag_column.rst
+++ b/docs/source/api/_api/time_stream.TimeFrame.decode_flag_column.rst
@@ -1,0 +1,7 @@
+﻿
+TimeFrame.decode_flag_column
+========================================
+
+.. currentmodule:: time_stream
+
+.. automethod:: TimeFrame.decode_flag_column

--- a/docs/source/api/_api/time_stream.TimeFrame.encode_flag_column.rst
+++ b/docs/source/api/_api/time_stream.TimeFrame.encode_flag_column.rst
@@ -1,0 +1,7 @@
+﻿
+TimeFrame.encode_flag_column
+========================================
+
+.. currentmodule:: time_stream
+
+.. automethod:: TimeFrame.encode_flag_column

--- a/docs/source/api/_api/time_stream.TimeFrame.filter_by_flag.rst
+++ b/docs/source/api/_api/time_stream.TimeFrame.filter_by_flag.rst
@@ -1,0 +1,7 @@
+﻿
+TimeFrame.filter_by_flag
+====================================
+
+.. currentmodule:: time_stream
+
+.. automethod:: TimeFrame.filter_by_flag

--- a/docs/source/api/_api/time_stream.aggregation.AggregationPipeline.rst
+++ b/docs/source/api/_api/time_stream.aggregation.AggregationPipeline.rst
@@ -1,0 +1,23 @@
+﻿time\_stream.aggregation.AggregationPipeline
+============================================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: AggregationPipeline
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~AggregationPipeline.__init__
+      ~AggregationPipeline.execute
+   
+   
+
+   
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.AngularMean.rst
+++ b/docs/source/api/_api/time_stream.aggregation.AngularMean.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.AngularMean
+====================================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: AngularMean
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~AngularMean.__init__
+      ~AngularMean.available
+      ~AngularMean.expr
+      ~AngularMean.get
+      ~AngularMean.post_expr
+      ~AngularMean.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~AngularMean.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.ConditionalCount.rst
+++ b/docs/source/api/_api/time_stream.aggregation.ConditionalCount.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.ConditionalCount
+=========================================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: ConditionalCount
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~ConditionalCount.__init__
+      ~ConditionalCount.available
+      ~ConditionalCount.expr
+      ~ConditionalCount.get
+      ~ConditionalCount.post_expr
+      ~ConditionalCount.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~ConditionalCount.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.Max.rst
+++ b/docs/source/api/_api/time_stream.aggregation.Max.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.Max
+============================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: Max
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Max.__init__
+      ~Max.available
+      ~Max.expr
+      ~Max.get
+      ~Max.post_expr
+      ~Max.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Max.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.Mean.rst
+++ b/docs/source/api/_api/time_stream.aggregation.Mean.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.Mean
+=============================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: Mean
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Mean.__init__
+      ~Mean.available
+      ~Mean.expr
+      ~Mean.get
+      ~Mean.post_expr
+      ~Mean.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Mean.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.MeanSum.rst
+++ b/docs/source/api/_api/time_stream.aggregation.MeanSum.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.MeanSum
+================================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: MeanSum
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~MeanSum.__init__
+      ~MeanSum.available
+      ~MeanSum.expr
+      ~MeanSum.get
+      ~MeanSum.post_expr
+      ~MeanSum.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~MeanSum.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.Min.rst
+++ b/docs/source/api/_api/time_stream.aggregation.Min.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.Min
+============================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: Min
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Min.__init__
+      ~Min.available
+      ~Min.expr
+      ~Min.get
+      ~Min.post_expr
+      ~Min.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Min.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.PeaksOverThreshold.rst
+++ b/docs/source/api/_api/time_stream.aggregation.PeaksOverThreshold.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.PeaksOverThreshold
+===========================================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: PeaksOverThreshold
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~PeaksOverThreshold.__init__
+      ~PeaksOverThreshold.available
+      ~PeaksOverThreshold.expr
+      ~PeaksOverThreshold.get
+      ~PeaksOverThreshold.post_expr
+      ~PeaksOverThreshold.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~PeaksOverThreshold.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.Percentile.rst
+++ b/docs/source/api/_api/time_stream.aggregation.Percentile.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.Percentile
+===================================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: Percentile
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Percentile.__init__
+      ~Percentile.available
+      ~Percentile.expr
+      ~Percentile.get
+      ~Percentile.post_expr
+      ~Percentile.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Percentile.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.StDev.rst
+++ b/docs/source/api/_api/time_stream.aggregation.StDev.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.StDev
+==============================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: StDev
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~StDev.__init__
+      ~StDev.available
+      ~StDev.expr
+      ~StDev.get
+      ~StDev.post_expr
+      ~StDev.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~StDev.name
+   
+   

--- a/docs/source/api/_api/time_stream.aggregation.Sum.rst
+++ b/docs/source/api/_api/time_stream.aggregation.Sum.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.aggregation.Sum
+============================
+
+.. currentmodule:: time_stream.aggregation
+
+.. autoclass:: Sum
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Sum.__init__
+      ~Sum.available
+      ~Sum.expr
+      ~Sum.get
+      ~Sum.post_expr
+      ~Sum.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Sum.name
+   
+   

--- a/docs/source/api/_api/time_stream.infill.AkimaInterpolation.rst
+++ b/docs/source/api/_api/time_stream.infill.AkimaInterpolation.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.infill.AkimaInterpolation
+======================================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: AkimaInterpolation
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~AkimaInterpolation.__init__
+      ~AkimaInterpolation.apply
+      ~AkimaInterpolation.available
+      ~AkimaInterpolation.get
+      ~AkimaInterpolation.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~AkimaInterpolation.min_points_required
+      ~AkimaInterpolation.name
+   
+   

--- a/docs/source/api/_api/time_stream.infill.AltData.rst
+++ b/docs/source/api/_api/time_stream.infill.AltData.rst
@@ -1,0 +1,32 @@
+﻿time\_stream.infill.AltData
+===========================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: AltData
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~AltData.__init__
+      ~AltData.apply
+      ~AltData.available
+      ~AltData.get
+      ~AltData.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~AltData.name
+   
+   

--- a/docs/source/api/_api/time_stream.infill.BSplineInterpolation.rst
+++ b/docs/source/api/_api/time_stream.infill.BSplineInterpolation.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.infill.BSplineInterpolation
+========================================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: BSplineInterpolation
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~BSplineInterpolation.__init__
+      ~BSplineInterpolation.apply
+      ~BSplineInterpolation.available
+      ~BSplineInterpolation.get
+      ~BSplineInterpolation.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~BSplineInterpolation.min_points_required
+      ~BSplineInterpolation.name
+   
+   

--- a/docs/source/api/_api/time_stream.infill.CubicInterpolation.rst
+++ b/docs/source/api/_api/time_stream.infill.CubicInterpolation.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.infill.CubicInterpolation
+======================================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: CubicInterpolation
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~CubicInterpolation.__init__
+      ~CubicInterpolation.apply
+      ~CubicInterpolation.available
+      ~CubicInterpolation.get
+      ~CubicInterpolation.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~CubicInterpolation.min_points_required
+      ~CubicInterpolation.name
+   
+   

--- a/docs/source/api/_api/time_stream.infill.InfillMethodPipeline.rst
+++ b/docs/source/api/_api/time_stream.infill.InfillMethodPipeline.rst
@@ -1,0 +1,23 @@
+﻿time\_stream.infill.InfillMethodPipeline
+========================================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: InfillMethodPipeline
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~InfillMethodPipeline.__init__
+      ~InfillMethodPipeline.execute
+   
+   
+
+   
+   
+   

--- a/docs/source/api/_api/time_stream.infill.LinearInterpolation.rst
+++ b/docs/source/api/_api/time_stream.infill.LinearInterpolation.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.infill.LinearInterpolation
+=======================================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: LinearInterpolation
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~LinearInterpolation.__init__
+      ~LinearInterpolation.apply
+      ~LinearInterpolation.available
+      ~LinearInterpolation.get
+      ~LinearInterpolation.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~LinearInterpolation.min_points_required
+      ~LinearInterpolation.name
+   
+   

--- a/docs/source/api/_api/time_stream.infill.PchipInterpolation.rst
+++ b/docs/source/api/_api/time_stream.infill.PchipInterpolation.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.infill.PchipInterpolation
+======================================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: PchipInterpolation
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~PchipInterpolation.__init__
+      ~PchipInterpolation.apply
+      ~PchipInterpolation.available
+      ~PchipInterpolation.get
+      ~PchipInterpolation.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~PchipInterpolation.min_points_required
+      ~PchipInterpolation.name
+   
+   

--- a/docs/source/api/_api/time_stream.infill.QuadraticInterpolation.rst
+++ b/docs/source/api/_api/time_stream.infill.QuadraticInterpolation.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.infill.QuadraticInterpolation
+==========================================
+
+.. currentmodule:: time_stream.infill
+
+.. autoclass:: QuadraticInterpolation
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~QuadraticInterpolation.__init__
+      ~QuadraticInterpolation.apply
+      ~QuadraticInterpolation.available
+      ~QuadraticInterpolation.get
+      ~QuadraticInterpolation.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~QuadraticInterpolation.min_points_required
+      ~QuadraticInterpolation.name
+   
+   

--- a/docs/source/api/_api/time_stream.qc.ComparisonCheck.rst
+++ b/docs/source/api/_api/time_stream.qc.ComparisonCheck.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.qc.ComparisonCheck
+===============================
+
+.. currentmodule:: time_stream.qc
+
+.. autoclass:: ComparisonCheck
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~ComparisonCheck.__init__
+      ~ComparisonCheck.apply
+      ~ComparisonCheck.available
+      ~ComparisonCheck.expr
+      ~ComparisonCheck.get
+      ~ComparisonCheck.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~ComparisonCheck.name
+   
+   

--- a/docs/source/api/_api/time_stream.qc.FlatLineCheck.rst
+++ b/docs/source/api/_api/time_stream.qc.FlatLineCheck.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.qc.FlatLineCheck
+=============================
+
+.. currentmodule:: time_stream.qc
+
+.. autoclass:: FlatLineCheck
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~FlatLineCheck.__init__
+      ~FlatLineCheck.apply
+      ~FlatLineCheck.available
+      ~FlatLineCheck.expr
+      ~FlatLineCheck.get
+      ~FlatLineCheck.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~FlatLineCheck.name
+   
+   

--- a/docs/source/api/_api/time_stream.qc.QcCheckPipeline.rst
+++ b/docs/source/api/_api/time_stream.qc.QcCheckPipeline.rst
@@ -1,0 +1,23 @@
+﻿time\_stream.qc.QcCheckPipeline
+===============================
+
+.. currentmodule:: time_stream.qc
+
+.. autoclass:: QcCheckPipeline
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~QcCheckPipeline.__init__
+      ~QcCheckPipeline.execute
+   
+   
+
+   
+   
+   

--- a/docs/source/api/_api/time_stream.qc.RangeCheck.rst
+++ b/docs/source/api/_api/time_stream.qc.RangeCheck.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.qc.RangeCheck
+==========================
+
+.. currentmodule:: time_stream.qc
+
+.. autoclass:: RangeCheck
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~RangeCheck.__init__
+      ~RangeCheck.apply
+      ~RangeCheck.available
+      ~RangeCheck.expr
+      ~RangeCheck.get
+      ~RangeCheck.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~RangeCheck.name
+   
+   

--- a/docs/source/api/_api/time_stream.qc.SpikeCheck.rst
+++ b/docs/source/api/_api/time_stream.qc.SpikeCheck.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.qc.SpikeCheck
+==========================
+
+.. currentmodule:: time_stream.qc
+
+.. autoclass:: SpikeCheck
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~SpikeCheck.__init__
+      ~SpikeCheck.apply
+      ~SpikeCheck.available
+      ~SpikeCheck.expr
+      ~SpikeCheck.get
+      ~SpikeCheck.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~SpikeCheck.name
+   
+   

--- a/docs/source/api/_api/time_stream.qc.TimeRangeCheck.rst
+++ b/docs/source/api/_api/time_stream.qc.TimeRangeCheck.rst
@@ -1,0 +1,33 @@
+﻿time\_stream.qc.TimeRangeCheck
+==============================
+
+.. currentmodule:: time_stream.qc
+
+.. autoclass:: TimeRangeCheck
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~TimeRangeCheck.__init__
+      ~TimeRangeCheck.apply
+      ~TimeRangeCheck.available
+      ~TimeRangeCheck.expr
+      ~TimeRangeCheck.get
+      ~TimeRangeCheck.register
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~TimeRangeCheck.name
+   
+   

--- a/docs/source/api/aggregation.rst
+++ b/docs/source/api/aggregation.rst
@@ -1,0 +1,37 @@
+.. _aggregation_api:
+
+===========
+Aggregation
+===========
+
+.. currentmodule:: time_stream
+
+.. automodule:: time_stream.aggregation
+    :no-members:
+
+Aggregation functions
+=====================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: _api/
+
+    ~AngularMean
+    ~ConditionalCount
+    ~Max
+    ~Mean
+    ~MeanSum
+    ~Min
+    ~PeaksOverThreshold
+    ~Percentile
+    ~StDev
+    ~Sum
+
+Pipeline
+========
+
+.. autosummary::
+    :nosignatures:
+    :toctree: _api/
+
+    ~AggregationPipeline

--- a/docs/source/api/infilling.rst
+++ b/docs/source/api/infilling.rst
@@ -1,0 +1,34 @@
+.. _infilling_api:
+
+=========
+Infilling
+=========
+
+.. currentmodule:: time_stream
+
+.. automodule:: time_stream.infill
+    :no-members:
+
+Infilling methods
+=================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: _api/
+
+    ~AltData
+    ~AkimaInterpolation
+    ~BSplineInterpolation
+    ~CubicInterpolation
+    ~LinearInterpolation
+    ~PchipInterpolation
+    ~QuadraticInterpolation
+
+Pipeline
+========
+
+.. autosummary::
+    :nosignatures:
+    :toctree: _api/
+
+    ~InfillMethodPipeline

--- a/docs/source/api/quality_control.rst
+++ b/docs/source/api/quality_control.rst
@@ -1,0 +1,32 @@
+.. _qc_api:
+
+===============
+Quality control
+===============
+
+.. currentmodule:: time_stream
+
+.. automodule:: time_stream.qc
+    :no-members:
+
+Quality control methods
+=======================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: _api/
+
+    ~ComparisonCheck
+    ~FlatLineCheck
+    ~RangeCheck
+    ~SpikeCheck
+    ~TimeRangeCheck
+
+Pipeline
+========
+
+.. autosummary::
+    :nosignatures:
+    :toctree: _api/
+
+    ~QcCheckPipeline

--- a/docs/source/api/time_frame.rst
+++ b/docs/source/api/time_frame.rst
@@ -4,6 +4,9 @@
 TimeFrame
 =========
 
+.. automodule:: time_stream.base
+     :no-members:
+
 .. currentmodule:: time_stream
 
 .. autoclass:: TimeFrame
@@ -82,3 +85,6 @@ Flagging
     ~TimeFrame.get_flag_column
     ~TimeFrame.add_flag
     ~TimeFrame.remove_flag
+    ~TimeFrame.decode_flag_column
+    ~TimeFrame.encode_flag_column
+    ~TimeFrame.filter_by_flag

--- a/docs/source/getting_started/concepts.rst
+++ b/docs/source/getting_started/concepts.rst
@@ -184,25 +184,26 @@ the end of the measurement, or a single instant?*.
 Flagging system
 ===============
 
-**What it is:** attaches status codes to data values without expanding the DataFrame schema with many new columns.
-Each flag is a named bit in an integer mask, meaning that multiple flags can be combined in one column.
+**What it is:** attaches status annotations to rows of your data without expanding the DataFrame schema
+with many new columns.
 
-- A ``flag system`` defines the available flags.
-- A ``flag column`` accompanies a data column, is governed by a *flag system*, and stores the combined bitmask.
+- A ``flag system`` defines the available flags and how they are stored. Three types are supported:
+
+  - **Bitwise** - flags are powers-of-two integers; multiple flags combine per row via bitwise OR.
+  - **Categorical single** - each row holds exactly one value from a set of named flags.
+  - **Categorical list** - each row holds a list of values, so multiple flags can coexist.
+
+- A ``flag column`` is a column in the DataFrame governed by a flag system. It stores the flag
+  values for each row.
 - Flags propagate alongside the data so downstream processes can test them quickly.
 
 .. mermaid::
 
    flowchart LR
-     %% Inputs
-     subgraph Data["Data column"]
-       D["flow"]
-     end
-
      subgraph Checks["QC checks"]
-       C1["Range check<br/>"]
-       C2["Spike check<br/>"]
-       C3["Error code check<br/>"]
+       C1["Range check"]
+       C2["Spike check"]
+       C3["Error code check"]
      end
 
      subgraph MapBits["Map to flags (enum)"]
@@ -216,33 +217,31 @@ Each flag is a named bit in an integer mask, meaning that multiple flags can be 
      end
 
      subgraph Flags["Flag column"]
-       F["flow_flag = 3"]
+       F["qc_flag = 3"]
      end
 
-     %% Edges
-     D --> C1 --> M1 --> OR
-     D --> C2 --> M2 --> OR
-     D --> C3
+     C1 --> M1 --> OR
+     C2 --> M2 --> OR
+     C3
 
      OR --> F
 
-     %% Decode path (optional)
      F -- decode --> MapBits
 
-     %% Style definitions
      classDef pass fill:#d1fad1,stroke:#237804,color:#000,stroke-width:1px;
      classDef fail fill:#ffe2e2,stroke:#a8071a,color:#000,stroke-width:1px;
 
-     %% Assign colors
      class C1 fail
      class C2 fail
      class C3 pass
 
 **Why it matters:**
 
-- Many flags can be packed into one integer column allowing for **compact storage**.
+- Multiple flags can be packed into one column allowing for **compact storage**.
 - Enables **traceability** in your data - you can see which values were infilled, estimated, or failed QC.
 - Provides **consistency**, as the same flag system can be reused across datasets and projects.
+
+See more details and examples here: :doc:`flagging user guide </user_guide/flagging>`
 
 Aggregation
 ===========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -117,6 +117,7 @@ This project is licensed under the `GNU General Public License v3.0 <https://git
     user_guide/rolling_aggregation
     user_guide/infilling
     user_guide/quality_control
+    user_guide/flagging
     user_guide/calculations
 
 .. toctree::
@@ -125,7 +126,9 @@ This project is licensed under the `GNU General Public License v3.0 <https://git
     :caption: API reference
 
     api/time_frame
-
+    api/aggregation
+    api/infilling
+    api/quality_control
 
 .. toctree::
     :hidden:

--- a/docs/source/user_guide/aggregation.rst
+++ b/docs/source/user_guide/aggregation.rst
@@ -139,6 +139,11 @@ The :meth:`~time_stream.TimeFrame.aggregate` method is the entry point for perfo
 timeseries data in **Time-Stream**. It combines **Polars performance** with **TimeFrame semantics**
 (resolution, periodicity, anchor).
 
+Let's look at the method in more detail:
+
+.. automethod:: time_stream.TimeFrame.aggregate
+   :no-index:
+
 Aggregation period
 ------------------
 
@@ -162,7 +167,6 @@ Aggregation methods
 -------------------
 
 Choose how values inside each window are summarised. Pass a **string** corresponding to one of the built-in functions.
-
 
 ``sum``
 ^^^^^^^
@@ -410,3 +414,12 @@ All aggregation functions can also be applied as rolling (sliding window) operat
 rolling aggregation preserves the original resolution and timestamps.
 
 See :doc:`rolling_aggregation` for a full guide including alignment options and worked examples.
+
+API reference
+=============
+
+.. autosummary::
+
+    ~time_stream.aggregation
+    ~time_stream.TimeFrame.aggregate
+    ~time_stream.TimeFrame.rolling_aggregate

--- a/docs/source/user_guide/flagging.rst
+++ b/docs/source/user_guide/flagging.rst
@@ -1,0 +1,537 @@
+.. _flagging:
+
+========
+Flagging
+========
+
+.. rst-class:: lead
+
+    The good, the bad, and the ugly - flexible, reversible flag annotations for every data point.
+
+Why use Time-Stream?
+====================
+
+Data values on their own rarely tells the whole story - readings go missing, sensors drift, values get corrected.
+Data analysts often need to know those details. **Time-Stream** lets you record every one of those caveats inline with
+the data itself, using flag systems **you define**, in a form compact enough to carry multiple annotations per row
+without losing detail.
+
+Simple example
+--------------
+
+Define your flags, link them to a column, and apply with a single call:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_1]
+   :end-before: [end_block_1]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.simple_example()
+
+A few lines to enrich the data: "I want to *flag* my *temperature* data as *SUSPECT* when values are *greater than 25*."
+
+Key benefits
+------------
+
+- **You define the vocabulary.**
+  Flag names, values, and meanings are yours to choose.
+
+- **Scalable.**
+  Multiple flag systems can coexist on the same TimeFrame.
+
+- **Flexible.**
+  Choose *bitwise*, *categorical single*, or *categorical list* flag systems to match your data.
+
+- **Reversible.**
+  Flags can be removed as easily as they are added, using the same expression-based interface.
+
+In more detail
+==============
+
+Flagging in **Time-Stream** is built around two concepts: `Flag systems`_ and `Flag columns`_.
+
+Flag systems
+------------
+
+A flag system is a user-defined set of named flags. **Time-Stream** supports three flag system types, each suited to
+a different annotation pattern. You pick the type via the ``flag_type`` argument of
+:meth:`~time_stream.TimeFrame.register_flag_system`, with ``"bitwise"`` as the default. Multiple flag systems can
+coexist on the same TimeFrame - for example a ``QC_FLAGS`` bitwise system alongside a ``PROVENANCE`` categorical list
+system.
+
+``bitwise``
+^^^^^^^^^^^
+
+    **What it does:** Stores flags as powers-of-two integers. Multiple flags combine on a single integer per row via
+    bitwise OR, so any combination of flags can be recorded without losing detail. See `Bitwise values`_ for the maths.
+
+    **When to use:** The default choice. Reach for this when a row may legitimately carry several compatible flags at
+    once (e.g. ``MISSING`` + ``INFILLED``) and you want compact storage.
+
+    **Accepted inputs to** ``register_flag_system``:
+
+    - ``None`` - produces a default system with a single ``FLAGGED`` flag at value ``1``:
+
+      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+         :language: python
+         :start-after: [start_block_3]
+         :end-before: [end_block_3]
+         :dedent:
+
+      .. jupyter-execute::
+         :hide-code:
+
+         import examples_flagging
+         examples_flagging.register_default()
+
+    - ``list[str]`` - names are sorted and assigned powers of two automatically:
+
+      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+         :language: python
+         :start-after: [start_block_4]
+         :end-before: [end_block_4]
+         :dedent:
+
+      .. jupyter-execute::
+         :hide-code:
+
+         import examples_flagging
+         examples_flagging.register_list()
+
+    - ``dict[str, int]`` - explicit mapping. Values must be powers of two and unique:
+
+      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+         :language: python
+         :start-after: [start_block_5]
+         :end-before: [end_block_5]
+         :dedent:
+
+      .. jupyter-execute::
+         :hide-code:
+
+         import examples_flagging
+         examples_flagging.register_bitwise_dict()
+
+    .. note::
+
+        Each value in a bitwise system must be a power of two (1, 2, 4, 8, 16, …) and unique within that system.
+        **Time-Stream** raises an error if you try to register an invalid bitwise system.
+
+
+``categorical``
+^^^^^^^^^^^^^^^
+
+    **What it does:** Each row holds exactly one value, or null. Values are arbitrary ``int`` or ``str`` - they do not
+    need to be powers of two. Setting a new flag replaces the previous value on each matching row, so flags are
+    mutually exclusive.
+
+    **When to use:** For "one verdict per row" annotations - e.g. an overall QC rating of ``good``, ``questionable``
+    or ``bad``, or a sensor status code column.
+
+    **Accepted inputs to** ``register_flag_system``:
+
+    - ``dict[str, int]`` with ``flag_type="categorical"`` - arbitrary integer values:
+
+      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+         :language: python
+         :start-after: [start_block_6]
+         :end-before: [end_block_6]
+         :dedent:
+
+      .. jupyter-execute::
+         :hide-code:
+
+         import examples_flagging
+         examples_flagging.register_categorical_single()
+
+    - ``dict[str, str]`` - string-valued dicts are inferred as categorical automatically, so ``flag_type`` can be
+      omitted:
+
+      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+         :language: python
+         :start-after: [start_block_7]
+         :end-before: [end_block_7]
+         :dedent:
+
+      .. jupyter-execute::
+         :hide-code:
+
+         import examples_flagging
+         examples_flagging.register_categorical_string()
+
+    - ``list[str]`` with ``flag_type="categorical"`` - each name is used as both the key and the value:
+
+      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+         :language: python
+         :start-after: [start_block_21]
+         :end-before: [end_block_21]
+         :dedent:
+
+      .. jupyter-execute::
+         :hide-code:
+
+         import examples_flagging
+         examples_flagging.register_categorical_name_list()
+
+
+``categorical_list``
+^^^^^^^^^^^^^^^^^^^^
+
+    **What it does:** Defines the same vocabulary as ``categorical``, but applied to a flag column each row holds a
+    *list* of values rather than a single one. Adding a flag appends to the list, so multiple flags can coexist on a
+    row - stored as distinct entries rather than combined bits.
+
+    **When to use:** When flags need to accumulate on a row but a bitwise encoding doesn't fit - for example a list of
+    provenance tags or free-form error codes where values are not powers of two.
+
+    **Accepted inputs to** ``register_flag_system``: The same forms as ``categorical`` above
+    (``dict[str, int]``, ``dict[str, str]``, or ``list[str]``), but with ``flag_type="categorical_list"``. The only
+    difference is when this flag system is applied to a flag column, a ``categorical_list`` system will allow
+    multiple flags per row.
+
+Flag columns
+------------
+
+A flag column is a column in the TimeFrame that has been registered against a specific flag system. They are where
+flags are stored for a given row in your data. Flag columns are what :meth:`~time_stream.TimeFrame.add_flag`,
+:meth:`~time_stream.TimeFrame.remove_flag`, :meth:`~time_stream.TimeFrame.filter_by_flag` methods operate on.
+
+There are two ways to create a flag column:
+
+**1. Initialise a new flag column** using :meth:`~time_stream.TimeFrame.init_flag_column`.
+
+This creates a new column in the DataFrame, populated with a sensible default, and registers it against the given
+flag system. The data type of the resulting column depends on the flag system type:
+
+- Bitwise: ``Int64``, initialised to ``0``.
+- Categorical single (int values): ``Int32``, initialised to ``null``.
+- Categorical single (string values): ``Utf8``, initialised to ``null``.
+- Categorical list: ``List`` of the underlying value type, initialised to an empty list.
+
+You can also pre-populate the column with a default flag value:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_10]
+   :end-before: [end_block_10]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.init_flag_column_prepopulated()
+
+.. note::
+    Normally, you would supply a sensible ``column_name`` so that you can keep track of your flags. However, if you
+    do omit it, the column is given a default name of ``__flag__{flag_system_name}``, with an integer suffix appended
+    if a name collides.
+
+    .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+       :language: python
+       :start-after: [start_block_9]
+       :end-before: [end_block_9]
+       :dedent:
+
+    .. jupyter-execute::
+       :hide-code:
+
+       import examples_flagging
+       examples_flagging.init_flag_column_default_name()
+
+**2. Register an existing column** using :meth:`~time_stream.TimeFrame.register_flag_column`.
+
+If you already have a column of the right data type containing valid flag values, you can register it without
+modifying the data:
+
+.. code-block:: python
+
+    tf.register_flag_column("temperature_flags", "CORE_FLAGS")
+
+**Time-Stream** validates that every non-null value in the column is a known flag value for the given flag system,
+and raises an error if any are not recognised.
+
+Adding flags
+------------
+
+Use :meth:`~time_stream.TimeFrame.add_flag` to set a flag on rows that match a given condition. The operation that
+this method does depends on the flag system type:
+
+- **Bitwise** - the flag is applied with a bitwise OR, so any existing flags on the row are preserved.
+- **Categorical single** - the flag replaces the current value on each matching row. Pass ``overwrite=False`` to
+  update only rows whose current value is null.
+- **Categorical list** - the flag is appended to the list on each matching row. Duplicate appends are a no-op.
+
+**Bitwise workflow:**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_11]
+   :end-before: [end_block_11]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.bitwise_flag_workflow()
+
+**Categorical single workflow:**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_12]
+   :end-before: [end_block_12]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.categorical_single_workflow()
+
+Each ``add_flag`` call overwrites the previous verdict on matching rows, so the order of calls matters. Use
+``overwrite=False`` to fill in only the rows that have no verdict yet:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_13]
+   :end-before: [end_block_13]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.categorical_single_overwrite()
+
+**Categorical list workflow:**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_14]
+   :end-before: [end_block_14]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.categorical_list_workflow()
+
+The ``flag_value`` argument accepts either the flag name as a string or its underlying value (integer or string,
+depending on the system). The ``expr`` argument is any valid Polars expression that returns a boolean Series, or a
+boolean Series directly (which is useful in conjunction with the boolean Series output from :doc:`quality_control`).
+If omitted, the flag is applied to all rows.
+
+
+Removing flags
+--------------
+
+Use :meth:`~time_stream.TimeFrame.remove_flag` to clear a flag from rows that match a given condition.
+
+- **Bitwise** - clears the bit with a bitwise AND NOT; other flags on the row are untouched.
+- **Categorical single** - sets the column value to null on matching rows.
+- **Categorical list** - removes all occurrences of the given value from the list on matching rows.
+
+.. code-block:: python
+
+    # Bitwise: clear SUSPECT from corrected rows
+    tf.remove_flag("temperature_flags", "SUSPECT", pl.col(tf.time_name) < correction_date)
+
+    # Categorical single: null out the QC verdict on a subset of rows
+    tf.remove_flag("temperature_qc", "bad", pl.col("temperature") < 20)
+
+    # Categorical list: drop a value from each matching row's list
+    tf.remove_flag("temperature_origin", "USER_INPUT")
+
+As with :meth:`~time_stream.TimeFrame.add_flag`, ``flag_value`` can be a name or underlying value, and ``expr`` is
+optional (defaults to all rows).
+
+.. note::
+
+    Removing a flag that is not set on a row has no effect - the operation is safe to call even when the flag is
+    absent.
+
+
+Filtering by flag
+-----------------
+
+Use :meth:`~time_stream.TimeFrame.filter_by_flag` to return a new TimeFrame containing only the rows that carry
+(or don't carry) given flags.
+
+**Keep only matching rows:**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_17]
+   :end-before: [end_block_17]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.filter_by_flag_include()
+
+**Drop matching rows** by passing ``include=False`` and a list of flags:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_18]
+   :end-before: [end_block_18]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.filter_by_flag_exclude()
+
+For bitwise columns, "matching" means any of the requested flag bits are set. For categorical columns, it means the
+row's value (or any element of the list, in list mode) is any of the requested flag values.
+
+
+Decoding and encoding flag columns
+----------------------------------
+
+Raw flag columns are compact but not particularly human-readable. Use :meth:`~time_stream.TimeFrame.decode_flag_column`
+to replace the raw values with their flag names:
+
+- **Bitwise** - the integer column becomes a ``List(String)`` column of active flag names (sorted by ascending bit
+  value). A value of ``0`` becomes an empty list.
+- **Categorical single** - each raw value becomes its flag name.
+- **Categorical list** - each value in each list becomes its flag name.
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_15]
+   :end-before: [end_block_15]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.decode_bitwise()
+
+Decoded columns remain registered as flag columns: :meth:`~time_stream.TimeFrame.add_flag`,
+:meth:`~time_stream.TimeFrame.remove_flag`, and :meth:`~time_stream.TimeFrame.filter_by_flag` all continue to work
+transparently on the decoded form.
+
+Use :meth:`~time_stream.TimeFrame.encode_flag_column` to round-trip the column back to raw values:
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+   :language: python
+   :start-after: [start_block_16]
+   :end-before: [end_block_16]
+   :dedent:
+
+.. jupyter-execute::
+   :hide-code:
+
+   import examples_flagging
+   examples_flagging.encode_bitwise()
+
+Integration with ``TimeStream`` operations
+==========================================
+
+The real power of the flagging systems comes into play when integrated with **Time-Stream**'s operations, such as
+:doc:`quality_control` and :doc:`infilling`. Both accept a ``flag_params`` tuple of ``(flag_column_name, flag_value)``
+that tells the operation to record its outcome directly into an existing flag column, rather than returning a standalone
+boolean series or leaving the infilled rows unmarked.
+
+This lets you build a single, self-describing :class:`~time_stream.TimeFrame` where every QC verdict or infilled
+value is traceable back to the check or method that produced it - no separate bookkeeping required.
+
+**Quality control checks** write the given flag value onto every row that fails the check:
+
+.. code-block:: python
+
+    tf.register_flag_system("QC_FLAGS", ["OUT_OF_RANGE", "SPIKE"])
+    tf.init_flag_column("QC_FLAGS", "temperature_qc")
+
+    # Flag values outside a plausible range
+    tf.qc_check(
+        "range", "temperature", min_value=-30, max_value=50,
+        flag_params=("temperature_qc", "OUT_OF_RANGE"),
+    )
+
+    # Flag spikes in the same column
+    tf.qc_check(
+        "spike", "temperature", threshold=10,
+        flag_params=("temperature_qc", "SPIKE"),
+    )
+
+See :doc:`quality_control` for the full set of available checks and the boolean-series alternative.
+
+**Infilling** marks rows that were filled in by the chosen method:
+
+.. code-block:: python
+
+    tf.register_flag_system("INFILL_FLAGS", ["INFILLED"])
+    tf.init_flag_column("INFILL_FLAGS", "flow_flags")
+
+    tf_infill = tf.infill(
+        "linear", "flow", max_gap_size=3,
+        flag_params=("flow_flags", "INFILLED"),
+    )
+
+See :doc:`infilling` for the full set of infill methods and options.
+
+Because the flag column lives alongside the data, you can then use :meth:`~time_stream.TimeFrame.filter_by_flag` to
+inspect or exclude affected rows, or decode the column for a human-readable audit trail.
+
+
+Additional information
+======================
+
+Bitwise values
+--------------
+
+Bitwise values are a set of integers where each value is a power of 2 (1, 2, 4, 8, 16, etc.). The key feature of
+bitwise values is that any combination of them results in a unique value. For example, ``1 + 4 = 5``. The value ``5``
+cannot be produced by any other combination of bitwise numbers. Similarly, the value ``13`` can only be produced by
+``1 + 4 + 8``.
+
+Bitwise values come from the binary number system, where each bit represents a power of 2.
+
+============  ============
+Decimal       Binary
+============  ============
+1             1
+2             10
+4             100
+8             1000
+16            10000
+============  ============
+
+With this we can see why combinations of bitwise values are unique. For example, ``5`` in binary is ``101``, which
+corresponds to the combination of ``1`` (``001``) and ``4`` (``100``).
+
+For **Time-Stream**, this feature allows any combination of flags from a bitwise flag system to be stored as a single
+integer value, without losing information about which flags are present. For example, if a data point is flagged as
+``48`` in the ``CORE_FLAGS`` flag system, we can deduce it has been both ``REMOVED`` (16) and ``INFILLED`` (32).
+
+API reference
+=============
+
+.. autosummary::
+
+    ~time_stream.TimeFrame.register_flag_system
+    ~time_stream.TimeFrame.with_flag_system
+    ~time_stream.TimeFrame.get_flag_system
+    ~time_stream.TimeFrame.init_flag_column
+    ~time_stream.TimeFrame.register_flag_column
+    ~time_stream.TimeFrame.get_flag_column
+    ~time_stream.TimeFrame.add_flag
+    ~time_stream.TimeFrame.remove_flag
+    ~time_stream.TimeFrame.filter_by_flag
+    ~time_stream.TimeFrame.decode_flag_column
+    ~time_stream.TimeFrame.encode_flag_column
+

--- a/docs/source/user_guide/flagging.rst
+++ b/docs/source/user_guide/flagging.rst
@@ -58,11 +58,14 @@ Flagging in **Time-Stream** is built around two concepts: `Flag systems`_ and `F
 Flag systems
 ------------
 
-A flag system is a user-defined set of named flags. **Time-Stream** supports three flag system types, each suited to
-a different annotation pattern. You pick the type via the ``flag_type`` argument of
-:meth:`~time_stream.TimeFrame.register_flag_system`, with ``"bitwise"`` as the default. Multiple flag systems can
-coexist on the same TimeFrame - for example a ``QC_FLAGS`` bitwise system alongside a ``PROVENANCE`` categorical list
-system.
+A flag system is a user-defined set of named flags. Each flag has a **name** (a human-readable label used as a
+descriptive lookup) and a **value** (the compact representation stored in the DataFrame). **Time-Stream** supports
+three flag system types, each suited to a different annotation pattern. You pick the type via the ``flag_type``
+argument of :meth:`~time_stream.TimeFrame.register_flag_system`, with ``"bitwise"`` as the default. Multiple flag
+systems can coexist on the same TimeFrame - for example a ``QC_FLAGS`` bitwise system alongside a ``PROVENANCE``
+categorical list system.
+
+.. _bitwise:
 
 ``bitwise``
 ^^^^^^^^^^^
@@ -126,14 +129,27 @@ system.
 ``categorical``
 ^^^^^^^^^^^^^^^
 
-    **What it does:** Each row holds exactly one value, or null. Values are arbitrary ``int`` or ``str`` - they do not
-    need to be powers of two. Setting a new flag replaces the previous value on each matching row, so flags are
-    mutually exclusive.
+    **What it does:** Each row holds exactly one value, or null. Values can be any ``int`` or ``str``. Setting a new
+    flag replaces the previous value on each matching row, so flags are mutually exclusive.
 
     **When to use:** For "one verdict per row" annotations - e.g. an overall QC rating of ``good``, ``questionable``
     or ``bad``, or a sensor status code column.
 
     **Accepted inputs to** ``register_flag_system``:
+
+    - ``list[str]`` with ``flag_type="categorical"`` - each name is used as both the name and the value:
+
+      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
+         :language: python
+         :start-after: [start_block_21]
+         :end-before: [end_block_21]
+         :dedent:
+
+      .. jupyter-execute::
+         :hide-code:
+
+         import examples_flagging
+         examples_flagging.register_categorical_name_list()
 
     - ``dict[str, int]`` with ``flag_type="categorical"`` - arbitrary integer values:
 
@@ -164,35 +180,29 @@ system.
          import examples_flagging
          examples_flagging.register_categorical_string()
 
-    - ``list[str]`` with ``flag_type="categorical"`` - each name is used as both the key and the value:
-
-      .. literalinclude:: ../../../src/time_stream/examples/examples_flagging.py
-         :language: python
-         :start-after: [start_block_21]
-         :end-before: [end_block_21]
-         :dedent:
-
-      .. jupyter-execute::
-         :hide-code:
-
-         import examples_flagging
-         examples_flagging.register_categorical_name_list()
-
-
 ``categorical_list``
 ^^^^^^^^^^^^^^^^^^^^
 
     **What it does:** Defines the same vocabulary as ``categorical``, but applied to a flag column each row holds a
-    *list* of values rather than a single one. Adding a flag appends to the list, so multiple flags can coexist on a
-    row - stored as distinct entries rather than combined bits.
+    *list* of values rather than a single one. Adding a flag appends to the list, so a row can carry multiple flags
+    simultaneously.
 
-    **When to use:** When flags need to accumulate on a row but a bitwise encoding doesn't fit - for example a list of
-    provenance tags or free-form error codes where values are not powers of two.
+    **When to use:** When you need multiple flags per row and your values are strings or integer codes - for example,
+    a list of provenance labels ("QC'ED", "INTERPOLATED") or numeric status codes (100, 404).
 
     **Accepted inputs to** ``register_flag_system``: The same forms as ``categorical`` above
     (``dict[str, int]``, ``dict[str, str]``, or ``list[str]``), but with ``flag_type="categorical_list"``. The only
     difference is when this flag system is applied to a flag column, a ``categorical_list`` system will allow
     multiple flags per row.
+
+    .. note::
+
+        ``categorical_list`` and `bitwise`_ both allow multiple flags to coexist on a single row. The difference is
+        in how they are stored: ``categorical_list`` keeps each flag value as a distinct entry in a list column,
+        making the raw data immediately readable; ``bitwise`` encodes all active flags into a single integer, which
+        is more compact but requires decoding to interpret. Either type supports
+        :meth:`~time_stream.TimeFrame.add_flag`, :meth:`~time_stream.TimeFrame.remove_flag`, and
+        :meth:`~time_stream.TimeFrame.filter_by_flag`.
 
 Flag columns
 ------------

--- a/docs/source/user_guide/infilling.rst
+++ b/docs/source/user_guide/infilling.rst
@@ -93,39 +93,110 @@ Each method has its strengths, depending on your data. The currently available m
 
 Simple infilling techniques
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ``"alt_data"`` - **infill using data from an alternative source.**
 
-  Either another column in your TimeFrame, or data from a different DataFrame entirely.
+``alt_data``
+^^^^^^^^^^^^
+:class:`time_stream.infill.AltData`
+
+    **What it does:** Infills using data from an alternative source - either another column in your
+    TimeFrame, or data from a different DataFrame entirely.
+
+    **When to use:** When you have a secondary data source that can stand in for missing values,
+    such as a nearby gauge or a modelled estimate.
+
+    **Additional args:**
+        ``alt_data_column``: The name of the column providing the alternative data.
+        ``correction_factor``: An optional multiplier to apply to the alternative data (default: 1.0).
+        ``alt_df``: A separate Polars DataFrame containing the alternative data. If omitted, the
+        column is taken from the current TimeFrame.
+
+    **Example usage:** ``tf_filled = tf.infill("alt_data", "flow", alt_data_column="flow_model", alt_df=model_df)``
 
 Polynomial interpolation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``"linear"`` - **straight-line interpolation between neighbouring points.**
+``linear``
+^^^^^^^^^^
+:class:`time_stream.infill.LinearInterpolation`
 
-  Simple and neutral; best for short gaps.
+    **What it does:** Straight-line interpolation between neighbouring known points.
 
-- ``"quadratic"`` - **second-order polynomial curve.**
+    **When to use:** Simple and neutral; best for short gaps where the underlying signal is
+    unlikely to curve significantly.
 
-  Captures gentle curvature; suitable when changes aren't linear.
+    **Additional args:** None.
 
-- ``"cubic"`` - **third-order polynomial curve.**
+    **Example usage:** ``tf_filled = tf.infill("linear", "flow", max_gap_size=3)``
 
-  Smooth transitions; can be useful for variables with cyclical patterns.
+``quadratic``
+^^^^^^^^^^^^^
+:class:`time_stream.infill.QuadraticInterpolation`
 
-- ``"bspline"`` - **B-spline interpolation (configurable order).**
+    **What it does:** Second-order polynomial curve through neighbouring known points.
 
-  Flexible piecewise polynomials; user decides.
+    **When to use:** Captures gentle curvature; suitable when changes are not strictly linear
+    but you do not need a high-order fit.
+
+    **Additional args:** None.
+
+    **Example usage:** ``tf_filled = tf.infill("quadratic", "flow", max_gap_size=3)``
+
+``cubic``
+^^^^^^^^^
+:class:`time_stream.infill.CubicInterpolation`
+
+    **What it does:** Third-order polynomial curve through neighbouring known points.
+
+    **When to use:** Produces smooth transitions; can be useful for variables with cyclical
+    patterns or gradually changing curvature.
+
+    **Additional args:** None.
+
+    **Example usage:** ``tf_filled = tf.infill("cubic", "flow", max_gap_size=3)``
+
+``bspline``
+^^^^^^^^^^^
+:class:`time_stream.infill.BSplineInterpolation`
+
+    **What it does:** B-spline interpolation with a configurable polynomial order.
+
+    **When to use:** When you want full control over the interpolation order. The other
+    polynomial methods (linear, quadratic, cubic) are convenience wrappers around this.
+
+    **Additional args:**
+        ``order``: Order of the B-spline (1-5, where 1=linear, 2=quadratic, 3=cubic).
+
+    **Example usage:** ``tf_filled = tf.infill("bspline", "flow", max_gap_size=3, order=4)``
 
 Shape-preserving methods
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``"pchip"`` - **Piecewise Cubic Hermite Interpolating Polynomial.**
+``pchip``
+^^^^^^^^^
+:class:`time_stream.infill.PchipInterpolation`
 
-  Preserves monotonicity and avoids overshoot; can help to avoid unrealistic fluctuations between values.
+    **What it does:** Piecewise Cubic Hermite Interpolating Polynomial.
 
-- ``"akima"`` - **Akima spline**.
+    **When to use:** Preserves monotonicity and avoids overshoot; can help to avoid unrealistic
+    fluctuations between known values. A good default when you want a smooth curve that respects
+    the shape of your data.
 
-  A smooth curve fit for data with significant local variations and potential outliers.
+    **Additional args:** None.
+
+    **Example usage:** ``tf_filled = tf.infill("pchip", "flow", max_gap_size=3)``
+
+``akima``
+^^^^^^^^^
+:class:`time_stream.infill.AkimaInterpolation`
+
+    **What it does:** Akima spline - a smooth curve fit that reduces oscillations near outliers.
+
+    **When to use:** Best for data with significant local variations and potential outliers,
+    where standard cubic interpolation might overshoot.
+
+    **Additional args:** None.
+
+    **Example usage:** ``tf_filled = tf.infill("akima", "flow", max_gap_size=5)``
 
 .. note::
 
@@ -166,7 +237,7 @@ Example:
        observation_interval=(datetime(2024, 1, 1), datetime(2024, 12, 31)),
    )
 
-This will only attempt infilling **between January to Decemeber 2024**; gaps outside that interval remain untouched.
+This will only attempt infilling **between January to December 2024**; gaps outside that interval remain untouched.
 
 Max gap size
 ------------
@@ -189,6 +260,33 @@ Example:
    The definition of "gap size" depends on the **TimeFrame resolution**.
    At 15-minute resolution, ``max_gap_size=2`` = 30 minutes; at daily resolution,
    ``max_gap_size=2`` = 2 days.
+
+Flagging infilled values
+------------------------
+
+When :meth:`~time_stream.TimeFrame.infill` replaces a null value with an interpolated one, you
+often want a record of which rows were touched. Pass ``flag_params=(flag_column_name, flag_value)``
+and **Time-Stream** will add the given flag to every row that went from null to non-null during
+the infill. The flag column must already exist - see :doc:`flagging` for how to create one.
+
+**Code:**
+
+.. literalinclude:: ../../../src/time_stream/examples/examples_infilling.py
+    :language: python
+    :start-after: [start_block_3]
+    :end-before: [end_block_3]
+    :dedent:
+
+**Output:**
+
+.. jupyter-execute::
+    :hide-code:
+
+    import examples_infilling
+    examples_infilling.flagged_infill()
+
+Only rows whose value changed from null to non-null are flagged; rows that were already populated,
+or that remain null because the gap exceeded ``max_gap_size``, are left untouched.
 
 Examples
 ========
@@ -264,3 +362,11 @@ You should do your research into which is most appropriate.
    tf = examples_infilling.all_infills()
 
 .. plot:: ../../src/time_stream/examples/examples_infilling.py plot_all_infills
+
+API reference
+=============
+
+.. autosummary::
+
+    ~time_stream.infilling
+    ~time_stream.TimeFrame.infill

--- a/docs/source/user_guide/quality_control.rst
+++ b/docs/source/user_guide/quality_control.rst
@@ -23,11 +23,12 @@ QC checks are lightweight, configurable, and explicit:
 .. code-block:: python
 
    tf_flagged = tf.qc_check(
-      "comparison", "rainfall", compare_to=0, operator="<", into="rainfall_flag"
+      "comparison", "rainfall", compare_to=0, operator="<",
+      flag_params=("rainfall_flag", "FLAGGED"),
    )
 
 A single call with rich meaning: "I want to *QC check* when my *rainfall* data is *less than* a value of *0*,
-with results saved to a column named *rainfall_flag*.
+and record the result in the *rainfall_flag* flag column."
 
 Key benefits
 ------------
@@ -48,189 +49,240 @@ In more detail
 ==============
 
 The :meth:`~time_stream.TimeFrame.qc_check` method applies a single QC check to one column.
-It can return a boolean mask (for filtering) or update the TimeFrame with a new column containing the results
-of the QC check. Each QC check is configurable through parameters specific to that check - see examples below.
+Each QC check is configurable through parameters specific to that check.
 
-Comparison check
-----------------
+Let's look at the method in more detail:
 
-Compare values against a constant or list using operators: ``<, <=, >, >=, ==, !=, is_in``.
+.. automethod:: time_stream.TimeFrame.qc_check
+   :no-index:
 
-Use for value thresholds or lists of error codes.
+Quality control methods
+-----------------------
 
-**Example: Temperature greater than or equal to 50:**
+``comparison``
+^^^^^^^^^^^^^^
+:class:`time_stream.qc.ComparisonCheck`
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_2]
-   :end-before: [end_block_2]
-   :dedent:
+    **What it does:** Compares values against a constant or list using a comparison operator
+    (``<``, ``<=``, ``>``, ``>=``, ``==``, ``!=``, ``is_in``).
 
-.. jupyter-execute::
-   :hide-code:
+    **When to use:** Use for value thresholds (e.g. negative rainfall) or matching against
+    lists of known error codes.
 
-   import examples_quality_control
-   examples_quality_control.comparison_qc_1()
+    **Additional args:**
+        ``compare_to``: The value (or list of values for ``is_in``) to compare against.
+        ``operator``: The comparison operator string.
+        ``flag_na``: If ``True``, also flag NaN/null values as failing the check (default: ``False``).
 
-**Example: Sensor codes within a list:**
+    **Example usage:**
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_4]
-   :end-before: [end_block_4]
-   :dedent:
+    **Temperature greater than or equal to 50:**
 
-.. jupyter-execute::
-   :hide-code:
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_2]
+       :end-before: [end_block_2]
+       :dedent:
 
-   import examples_quality_control
-   examples_quality_control.comparison_qc_3()
+    .. jupyter-execute::
+       :hide-code:
 
-Range check
------------
+       import examples_quality_control
+       examples_quality_control.comparison_qc_1()
 
-Check if values lie inside or outside a min-max interval.
+    **Sensor codes within a list:**
 
-Use for physical plausibility bounds (e.g. temperature between -30 and 50 °C).
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_4]
+       :end-before: [end_block_4]
+       :dedent:
 
-**Example: Temperatures outside of the range -30 to 50:**
+    .. jupyter-execute::
+       :hide-code:
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_5]
-   :end-before: [end_block_5]
-   :dedent:
+       import examples_quality_control
+       examples_quality_control.comparison_qc_3()
 
-.. jupyter-execute::
-   :hide-code:
+``range``
+^^^^^^^^^
+:class:`time_stream.qc.RangeCheck`
 
-   import examples_quality_control
-   examples_quality_control.range_qc_1()
+    **What it does:** Checks whether values fall inside or outside a min-max interval.
 
-Time range check
-----------------
+    **When to use:** Use for physical plausibility bounds, such as temperature between -30 and 50°C
 
-Flag data between specific time ranges.
+    **Additional args:**
+        ``min_value``: Minimum of the range.
+        ``max_value``: Maximum of the range.
+        ``closed``: Which sides of the interval are inclusive - ``"both"``, ``"left"``, ``"right"``, or ``"none"`` (default: ``"both"``).
+        ``within``: Whether to flag values within the range (``True``, default) or outside it (``False``).
 
-Use for known bad periods such as sensor outages or calibration times.
+    **Example usage:**
 
-**Example: Flag rainfall values between the hours of 01:00 and 03:00:**
+    **Temperatures outside of the range -30 to 50:**
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_9]
-   :end-before: [end_block_9]
-   :dedent:
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_5]
+       :end-before: [end_block_5]
+       :dedent:
 
-.. jupyter-execute::
-   :hide-code:
+    .. jupyter-execute::
+       :hide-code:
 
-   import examples_quality_control
-   examples_quality_control.time_range_qc_1()
+       import examples_quality_control
+       examples_quality_control.range_qc_1()
 
-**Example: Flag temperature values between 03:30 and 09:30 on the 1st January:**
+``time_range``
+^^^^^^^^^^^^^^
+:class:`time_stream.qc.TimeRangeCheck`
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_10]
-   :end-before: [end_block_10]
-   :dedent:
+    **What it does:** Flags rows where the primary time column falls within a given range. Accepts
+    ``datetime.time``, ``datetime.date``, or ``datetime.datetime`` bounds.
 
-.. jupyter-execute::
-   :hide-code:
+    **When to use:** Use for known bad periods such as sensor outages or automated calibration
+    times.
 
-   import examples_quality_control
-   examples_quality_control.time_range_qc_2()
+    **Additional args:**
+        ``min_value``: Start of the time range.
+        ``max_value``: End of the time range.
+        ``closed``: Which sides of the interval are inclusive - ``"both"``, ``"left"``, ``"right"``, or ``"none"`` (default: ``"both"``).
+        ``within``: Whether to flag values within the range (``True``, default) or outside it (``False``).
 
-Spike check
------------
+    **Example usage:**
 
-Detect sudden jumps using neighbour differences.
+    **Flag rainfall values between the hours of 01:00 and 03:00:**
 
-Use for unrealistic single-point spikes.
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_9]
+       :end-before: [end_block_9]
+       :dedent:
 
-**Example: Spike check on temperature data:**
+    .. jupyter-execute::
+       :hide-code:
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_7]
-   :end-before: [end_block_7]
-   :dedent:
+       import examples_quality_control
+       examples_quality_control.time_range_qc_1()
 
-.. jupyter-execute::
-   :hide-code:
+    **Flag temperature values between 03:30 and 09:30 on the 1st January:**
 
-   import examples_quality_control
-   examples_quality_control.spike_qc_1()
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_10]
+       :end-before: [end_block_10]
+       :dedent:
 
-.. note::
-    The result doesn't flag the neighbouring high values of 50 and 52. The spike test detects a sudden
-    jump where one value sits between otherwise normal values.
+    .. jupyter-execute::
+       :hide-code:
 
-.. note::
-    The result returns ``null`` for the first and last values; the spike test relies on comparisons with
-    neighbouring values.
+       import examples_quality_control
+       examples_quality_control.time_range_qc_2()
 
-Flat line check
----------------
+``spike``
+^^^^^^^^^
+:class:`time_stream.qc.SpikeCheck`
 
-Detect consecutive repeated (or near-repeated) values.
+    **What it does:** Detects sudden jumps by assessing differences with neighbouring values.
+    A point is flagged when the combined neighbour difference (minus skew) exceeds twice the
+    threshold.
 
-Use when a sensor stuck at a fixed value should be flagged as suspect.
+    **When to use:** Use for detecting unrealistic single-point spikes - isolated values that
+    jump sharply compared to their neighbours.
 
-**Example: Flag temperature values stuck at the same reading for 3 or more consecutive timesteps:**
+    **Additional args:**
+        ``threshold``: The spike detection threshold.
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_11]
-   :end-before: [end_block_11]
-   :dedent:
+    **Example usage:**
 
-.. jupyter-execute::
-   :hide-code:
+    **Spike check on temperature data:**
 
-   import examples_quality_control
-   examples_quality_control.flat_line_qc_1()
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_7]
+       :end-before: [end_block_7]
+       :dedent:
 
-**Example: Using** ``ignore_value`` **- suppress flagging when the repeated value is 0.0:**
+    .. jupyter-execute::
+       :hide-code:
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_12]
-   :end-before: [end_block_12]
-   :dedent:
+       import examples_quality_control
+       examples_quality_control.spike_qc_1()
 
-.. jupyter-execute::
-   :hide-code:
+    .. note::
+        The result doesn't flag the neighbouring high values of 50 and 52. The spike test detects a sudden
+        jump where one value sits between otherwise normal values.
 
-   import examples_quality_control
-   examples_quality_control.flat_line_qc_2()
+    .. note::
+        The result returns ``null`` for the first and last values; the spike test relies on comparisons with
+        neighbouring values.
 
-.. note::
-    More than one ``ignore_value`` can be specified in a list, e.g. [0.0, 20.0]
+``flat_line``
+^^^^^^^^^^^^^
+:class:`time_stream.qc.FlatLineCheck`
 
-**Example: Using** ``tolerance`` **- flag values that barely change (within 0.01) for 3 or more consecutive readings:**
+    **What it does:** Detects consecutive repeated (or near-repeated) values in a column.
 
-The data below drifts slightly around 20 °C (varying by less than 0.01 between readings) before jumping
-to a different range. The ``tolerance`` parameter catches these near-flat runs that exact equality would miss.
+    **When to use:** Use when a sensor stuck at a fixed value should be flagged as suspect.
 
-.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
-   :language: python
-   :start-after: [start_block_13]
-   :end-before: [end_block_13]
-   :dedent:
+    **Additional args:**
+        ``min_count``: Minimum number of consecutive repeated values required for a flat line (must be at least 2).
+        ``tolerance``: Optional tolerance for near-equality comparison. When set, consecutive values differing by less than or equal to this amount are considered equal (default: ``None``, exact equality).
+        ``ignore_value``: Optional value or list of values that are allowed to repeat without being flagged.
 
-.. jupyter-execute::
-   :hide-code:
+    **Example usage:**
 
-   import examples_quality_control
-   examples_quality_control.flat_line_qc_3()
+    **Flag temperature values stuck at the same reading for 3 or more consecutive timesteps:**
 
-Additional parameters
-=====================
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_11]
+       :end-before: [end_block_11]
+       :dedent:
+
+    .. jupyter-execute::
+       :hide-code:
+
+       import examples_quality_control
+       examples_quality_control.flat_line_qc_1()
+
+    **Using** ``ignore_value`` **- suppress flagging when the repeated value is 0.0:**
+
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_12]
+       :end-before: [end_block_12]
+       :dedent:
+
+    .. jupyter-execute::
+       :hide-code:
+
+       import examples_quality_control
+       examples_quality_control.flat_line_qc_2()
+
+    .. note::
+        More than one ``ignore_value`` can be specified in a list, e.g. [0.0, 20.0]
+
+    **Using** ``tolerance`` **- flag values that barely change (within 0.01) for 3 or more consecutive readings:**
+
+    The data below drifts slightly around 20 °C (varying by less than 0.01 between readings) before jumping
+    to a different range. The ``tolerance`` parameter catches these near-flat runs that exact equality would miss.
+
+    .. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+       :language: python
+       :start-after: [start_block_13]
+       :end-before: [end_block_13]
+       :dedent:
+
+    .. jupyter-execute::
+       :hide-code:
+
+       import examples_quality_control
+       examples_quality_control.flat_line_qc_3()
 
 Observation interval
---------------------
+====================
 
 Specify an observation interval to restrict the QC check to a **specific time window**. This is useful when:
 
@@ -238,15 +290,32 @@ Specify an observation interval to restrict the QC check to a **specific time wi
 - You need to re-run checks on recent data without reprocessing the full archive.
 - You want to exclude known bad periods (e.g. sensor maintenance) from checks.
 
-Into
-----
+Flag Parameters
+===============
+The result of a QC check can be consumed in one of two ways, selected via the ``flag_params`` argument:
 
-The ``into`` argument controls what you get back:
+- **Boolean series** (default, ``flag_params`` omitted) - ``qc_check`` returns a Polars boolean
+  ``Series`` of the same length as the TimeFrame, with ``True`` marking the rows that failed the
+  check. Useful for chaining into custom expressions or feeding into
+  :meth:`~time_stream.TimeFrame.add_flag` manually.
+- **Flag column update** (``flag_params=(flag_column_name, flag_value)``) - ``qc_check`` adds the
+  given flag value to the named flag column on each failing row and returns a new TimeFrame. The
+  flag column must already exist (see :doc:`flagging`).
 
-- ``into=False`` → return a boolean Series (mask of failed rows).
-- ``into=True`` → add a new boolean column with an automatic name.
-- ``into="my_column"`` → add a new boolean column with a custom name.
+The examples below use the flag-column style. Each sets up a bitwise flag system with a single
+``FLAGGED`` flag and calls :meth:`~time_stream.TimeFrame.init_flag_column` before running the
+check:
 
-.. note::
+.. literalinclude:: ../../../src/time_stream/examples/examples_quality_control.py
+   :language: python
+   :start-after: [start_block_14]
+   :end-before: [end_block_14]
+   :dedent:
 
-   If a column name already exists, **Time-Stream** auto-suffixes it to avoid overwriting.
+API reference
+=============
+
+.. autosummary::
+
+    ~time_stream.qc
+    ~time_stream.TimeFrame.qc_check

--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -1,34 +1,34 @@
 """
 Core TimeFrame Data Model.
 
-This module defines the `TimeFrame` class, the central abstraction of the time_stream package.
-A `TimeFrame` wraps a Polars DataFrame and adds functionality for handling temporal data, quality flags, metadata, and
-derived operations.
+This module defines the :class:`TimeFrame` class, the central abstraction of the time_stream package.
+A :class:`TimeFrame` wraps a Polars DataFrame and adds functionality for handling temporal data, quality flags,
+metadata, and derived operations.
 
 Main responsibilities
 ---------------------
-1. **Time management** (via `TimeManager`):
+1. **Time management**:
    - Validates that the time column exists and has a temporal dtype.
    - Enforces resolution and periodicity of the time series.
-   - Uses time anchoring to define the period over which values are valid (`POINT`, `START`, `END`).
-   - Detects duplicates and resolves them according to a strategy (`ERROR`, `KEEP_FIRST`, `KEEP_LAST`, `DROP`, `MERGE`).
+   - Uses time anchoring to define the period over which values are valid.
+   - Detects duplicates and resolves them according to a strategy.
    - Prevents mutation of time values between operations.
 
 2. **Metadata management**:
    - TimeFrame-level metadata (`.metadata`).
    - Per-column metadata (`.column_metadata`) that stays in sync with the DataFrame.
 
-3. **Flag management** (via `FlagManager`):
-   - Register reusable flag systems (`BitwiseFlag` or `CategoricalFlag`).
+3. **Flag management**:
+   - Register reusable flag systems.
    - Initialise flag columns linked to data columns.
    - Add/remove flags with Polars expressions.
    - Filter TimeFrame based on flag values
 
 4. **Data operations**:
-   - Aggregation: run `AggregationFunction` pipelines with support for missing-data criteria and time anchoring.
-   - Quality control: apply `QCCheck` classes to detect anomalies or enforce validation rules.
-   - Infilling: apply `InfillMethod` classes to fill missing values according to defined strategies.
-   - Column selection: return reduced TimeFrame with metadata and flags synced consistently.
+   - Aggregation: run aggregation pipelines with support for missing-data criteria and time anchoring.
+   - Quality control: apply quality control routines to detect anomalies or enforce validation rules.
+   - Infilling: apply infill methods to fill missing values according to defined strategies.
+   - Column selection: return reduced :class:`TimeFrame` with metadata and flags synced consistently.
 """
 
 from __future__ import annotations
@@ -443,14 +443,12 @@ class TimeFrame:
 
         Args:
             name: Short name for the flag system.
-            flag_system: The flag system definition. Accepted types:
-                - ``None`` - produces a default bitwise system with a single ``FLAGGED`` flag at value 1.
-                - ``dict[str, int]`` - bitwise or categorical depending on ``flag_type``.
-                  Bitwise values must be powers of two.
-                - ``dict[str, str]`` - always categorical; ``flag_type`` is ignored.
-                - ``list[str]`` - flag names are sorted; bitwise assigns powers of two, categorical
-                  assigns sequential integers starting from 0. An empty list produces the default
-                  ``FLAGGED`` flag.
+            flag_system: The flag system definition. Accepted types are ``None`` (default bitwise
+                system with a single ``FLAGGED`` flag at value 1), ``dict[str, int]`` (bitwise or
+                categorical depending on ``flag_type`` - bitwise values must be powers of two),
+                ``dict[str, str]`` (always categorical; ``flag_type`` is ignored), or ``list[str]``
+                (flag names are sorted; bitwise assigns powers of two, categorical uses each name
+                as both key and value - an empty list produces the default ``FLAGGED`` flag).
             flag_type: Whether to create a ``"bitwise"`` or ``"categorical"`` flag system. Only
                 relevant when ``flag_system`` is a ``dict[str, int]`` or ``list[str]``.
         """
@@ -868,19 +866,6 @@ class TimeFrame:
 
         Returns:
             Result of the QC check, either as a boolean Series or added to the TimeFrame dataframe
-
-        Examples:
-            # Threshold check
-            ts_flagged = tf.qc_check("comparison", "battery_voltage", compare_to=12.0, operator="<")
-
-            # Range check
-            ts_flagged = tf.qc_check("range", "temperature", min_value=-50, max_value=50)
-
-            # Spike check
-            ts_flagged = tf.qc_check("spike", "wind_speed", threshold=5.0)
-
-            # Value check for error codes
-            ts_flagged = tf.qc_check("comparison", "status_code", compare_to=[99, -999, "ERROR"])
         """
         # Get the QC check instance and run the apply method
         check_instance = QCCheck.get(check, **kwargs)

--- a/src/time_stream/examples/examples_flagging.py
+++ b/src/time_stream/examples/examples_flagging.py
@@ -1,0 +1,300 @@
+from datetime import datetime, timedelta
+
+import polars as pl
+
+import time_stream as ts
+from time_stream.examples.utils import suppress_output
+
+
+def _temperature_tf() -> ts.TimeFrame:
+    dates = [datetime(2023, 1, 1) + timedelta(days=i) for i in range(10)]
+    temperature = [20.5, 21.0, None, 26.0, 24.2, 26.6, 28.4, 30.9, 31.0, 29.1]
+    df = pl.DataFrame({"time": dates, "temperature": temperature})
+    return ts.TimeFrame(df=df, time_name="time")
+
+
+def simple_example() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_1]
+    core_flags = ["UNCHECKED", "MISSING", "SUSPECT", "CORRECTED"]
+
+    # Register the flag system into the TimeFrame
+    tf.register_flag_system("CORE_FLAGS", core_flags, flag_type="categorical")
+
+    # Initialise a new flag column tied to the CORE_FLAGS system
+    tf.init_flag_column("CORE_FLAGS", "temperature_flags")
+
+    # Flag rows where the temperature exceeds 25 as SUSPECT
+    tf.add_flag("temperature_flags", "SUSPECT", pl.col("temperature") > 25)
+    # [end_block_1]
+    print(tf.df)
+
+
+def register_default() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_3]
+    # Default bitwise system - a single FLAGGED flag at value 1
+    tf.register_flag_system("DEFAULT")
+    # [end_block_3]
+    print(tf.get_flag_system("DEFAULT"))
+
+
+def register_list() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_4]
+    # Pass a list of names and let Time-Stream assign powers of two
+    tf.register_flag_system("QC_FLAGS", ["OUT_OF_RANGE", "SPIKE", "FLATLINE", "ERROR_CODE"])
+    # [end_block_4]
+    print(tf.get_flag_system("QC_FLAGS"))
+
+
+def register_bitwise_dict() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_5]
+    core_flags = {
+        "UNCHECKED": 1,
+        "MISSING": 2,
+        "SUSPECT": 4,
+        "CORRECTED": 8,
+        "REMOVED": 16,
+        "INFILLED": 32,
+    }
+    tf.register_flag_system("CORE_FLAGS", core_flags)
+    # [end_block_5]
+    print(tf.get_flag_system("CORE_FLAGS"))
+
+
+def register_categorical_single() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_6]
+    # A categorical single system - each row holds exactly one value
+    qc = {"good": 0, "questionable": 1, "bad": 2}
+    tf.register_flag_system("QC", qc, flag_type="categorical")
+    # [end_block_6]
+    print(tf.get_flag_system("QC"))
+
+
+def register_categorical_string() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_7]
+    # String values imply categorical automatically
+    codes = {"good": "G", "questionable": "Q", "bad": "B"}
+    tf.register_flag_system("CODES", codes)
+    # [end_block_7]
+    print(tf.get_flag_system("CODES"))
+
+
+def register_categorical_name_list() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_21]
+    # A list of names, each used as both the key and the value
+    tf.register_flag_system("QC", ["good", "questionable", "bad"], flag_type="categorical")
+    # [end_block_21]
+    print(tf.get_flag_system("QC"))
+
+
+def register_categorical_list() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_8]
+    # A categorical list system - each row holds a list of values
+    tf.register_flag_system(
+        "ORIGIN",
+        ["API", "USER_INPUT", "MODEL_OUTPUT", "DERIVED"],
+        flag_type="categorical_list",
+    )
+    # [end_block_8]
+    print(tf.get_flag_system("ORIGIN"))
+
+
+def init_flag_column_default_name() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("CORE_FLAGS", {"UNCHECKED": 1, "SUSPECT": 4})
+
+    # [start_block_9]
+    tf.init_flag_column("CORE_FLAGS")
+    # [end_block_9]
+    print(tf.flag_columns)
+
+
+def init_flag_column_prepopulated() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("CORE_FLAGS", {"UNCHECKED": 1, "SUSPECT": 4})
+
+    # [start_block_10]
+    # Pre-populate every row with the UNCHECKED flag (value 1)
+    tf.init_flag_column("CORE_FLAGS", column_name="temperature_flags", data=1)
+    # [end_block_10]
+    print(tf.df)
+
+
+def bitwise_flag_workflow() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_11]
+    tf.register_flag_system("CORE_FLAGS", {"UNCHECKED": 1, "MISSING": 2, "SUSPECT": 4})
+    tf.init_flag_column("CORE_FLAGS", "temperature_flags")
+
+    tf.add_flag("temperature_flags", "MISSING", pl.col("temperature").is_null())
+    tf.add_flag("temperature_flags", "SUSPECT", pl.col("temperature") > 25)
+    tf.add_flag("temperature_flags", "UNCHECKED", pl.col("temperature") < 25)
+    # [end_block_11]
+    print(tf.df)
+
+
+def categorical_single_workflow() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_12]
+    tf.register_flag_system("QC", {"good": 0, "questionable": 1, "bad": 2}, flag_type="categorical")
+    tf.init_flag_column("QC", "temperature_qc")
+
+    # Each row carries exactly one value; later add_flag calls replace the previous value
+    tf.add_flag("temperature_qc", "good")
+    tf.add_flag("temperature_qc", "questionable", pl.col("temperature") > 25)
+    tf.add_flag("temperature_qc", "bad", pl.col("temperature") > 30)
+    # [end_block_12]
+    print(tf.df)
+
+
+def categorical_single_overwrite() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("QC", {"good": 0, "bad": 2}, flag_type="categorical")
+        tf.init_flag_column("QC", "temperature_qc")
+        tf.add_flag("temperature_qc", "bad", pl.col("temperature") > 25)
+
+    # [start_block_13]
+    # overwrite=False leaves rows that already have a value untouched
+    tf.add_flag("temperature_qc", "good", overwrite=False)
+    # [end_block_13]
+    print(tf.df)
+
+
+def categorical_list_workflow() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_14]
+    tf.register_flag_system(
+        "ORIGIN",
+        ["API", "USER_INPUT", "MODEL_OUTPUT"],
+        flag_type="categorical_list",
+    )
+    tf.init_flag_column("ORIGIN", "temperature_origin")
+
+    # Append values to each row's list - flags coexist
+    tf.add_flag("temperature_origin", "API")
+    tf.add_flag("temperature_origin", "USER_INPUT", pl.col("temperature") > 25)
+    # [end_block_14]
+    print(tf.df)
+
+
+def decode_bitwise() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("CORE_FLAGS", {"MISSING": 2, "SUSPECT": 4, "CORRECTED": 8})
+        tf.init_flag_column("CORE_FLAGS", "temperature_flags")
+        tf.add_flag("temperature_flags", "MISSING", pl.col("temperature").is_null())
+        tf.add_flag("temperature_flags", "SUSPECT", pl.col("temperature") > 25)
+        tf.add_flag(
+            "temperature_flags",
+            "CORRECTED",
+            (pl.col(tf.time_name) < datetime(2023, 1, 5)) & pl.col("temperature").is_not_null(),
+        )
+
+    # [start_block_15]
+    # Replace the raw integer flag column with human-readable flag names
+    tf_decoded = tf.decode_flag_column("temperature_flags")
+    # [end_block_15]
+    print(tf_decoded.df)
+
+
+def encode_bitwise() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("CORE_FLAGS", {"MISSING": 2, "SUSPECT": 4, "CORRECTED": 8})
+        tf.init_flag_column("CORE_FLAGS", "temperature_flags")
+        tf.add_flag("temperature_flags", "MISSING", pl.col("temperature").is_null())
+        tf.add_flag("temperature_flags", "SUSPECT", pl.col("temperature") > 25)
+        tf_decoded = tf.decode_flag_column("temperature_flags")
+
+    # [start_block_16]
+    # Round-trip a decoded flag column back to raw integers
+    tf_encoded = tf_decoded.encode_flag_column("temperature_flags")
+    # [end_block_16]
+    print(tf_encoded.df)
+
+
+def filter_by_flag_include() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("CORE_FLAGS", {"MISSING": 2, "SUSPECT": 4})
+        tf.init_flag_column("CORE_FLAGS", "temperature_flags")
+        tf.add_flag("temperature_flags", "MISSING", pl.col("temperature").is_null())
+        tf.add_flag("temperature_flags", "SUSPECT", pl.col("temperature") > 25)
+
+    # [start_block_17]
+    # Keep only rows flagged as SUSPECT
+    tf_suspect = tf.filter_by_flag("temperature_flags", "SUSPECT")
+    # [end_block_17]
+    print(tf_suspect.df)
+
+
+def filter_by_flag_exclude() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("CORE_FLAGS", {"MISSING": 2, "SUSPECT": 4})
+        tf.init_flag_column("CORE_FLAGS", "temperature_flags")
+        tf.add_flag("temperature_flags", "MISSING", pl.col("temperature").is_null())
+        tf.add_flag("temperature_flags", "SUSPECT", pl.col("temperature") > 25)
+
+    # [start_block_18]
+    # Drop rows flagged as MISSING or SUSPECT
+    tf_clean = tf.filter_by_flag("temperature_flags", ["MISSING", "SUSPECT"], include=False)
+    # [end_block_18]
+    print(tf_clean.df)
+
+
+def inspect_flag_columns() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+        tf.register_flag_system("CORE_FLAGS", {"UNCHECKED": 1, "SUSPECT": 4})
+        tf.init_flag_column("CORE_FLAGS", "temperature_flags")
+
+    # [start_block_19]
+    print(tf.flag_columns)
+    flag_col = tf.get_flag_column("temperature_flags")
+    print(flag_col.name)
+    print(flag_col.flag_system)
+    # [end_block_19]
+
+
+def with_flag_system_example() -> None:
+    with suppress_output():
+        tf = _temperature_tf()
+
+    # [start_block_20]
+    # Immutable variant - returns a new TimeFrame
+    tf_with_flags = tf.with_flag_system("CORE_FLAGS", {"UNCHECKED": 1, "SUSPECT": 4})
+    # [end_block_20]
+    print(tf_with_flags.flag_systems)

--- a/src/time_stream/examples/examples_infilling.py
+++ b/src/time_stream/examples/examples_infilling.py
@@ -89,6 +89,25 @@ def alt_data_infill() -> None:
     print(tf_infill.df)
 
 
+def flagged_infill() -> None:
+    with suppress_output():
+        df = get_example_df(library="polars")
+
+    tf = ts.TimeFrame(df, "time", resolution="PT15M", periodicity="PT15M")
+
+    # [start_block_3]
+    # Register a flag system and create a flag column before running infill
+    tf.register_flag_system("INFILL_FLAGS", ["INFILLED"])
+    tf.init_flag_column("INFILL_FLAGS", "flow_flags")
+
+    # Run the infill and mark rows that were filled in
+    tf_infill = tf.infill("linear", "flow", max_gap_size=3, flag_params=("flow_flags", "INFILLED"))
+    # [end_block_3]
+
+    with pl.Config(tbl_rows=16):
+        print(tf_infill.df)
+
+
 def all_infills() -> pl.DataFrame:
     with suppress_output():
         tf = create_simple_time_series_with_gaps()

--- a/src/time_stream/examples/examples_quality_control.py
+++ b/src/time_stream/examples/examples_quality_control.py
@@ -17,8 +17,15 @@ def create_simple_time_series() -> ts.TimeFrame:
     )
 
     tf = ts.TimeFrame(df=df, time_name="timestamp")
-    tf.register_flag_system("qc", {"FLAGGED": 1})
+    tf = setup_flags(tf)
+    return tf
 
+
+def setup_flags(tf: ts.TimeFrame) -> ts.TimeFrame:
+    # [start_block_14]
+    tf.register_flag_system("qc", {"FLAGGED": 1})
+    tf.init_flag_column("qc", "flag_column")
+    # [end_block_14]
     return tf
 
 
@@ -28,9 +35,9 @@ def comparison_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_2]
-    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "comparison", "temperature", compare_to=50, operator=">=", flag_params=("flag_temperature", "FLAGGED")
+        "comparison", "temperature", compare_to=50, operator=">=",
+        flag_params=("flag_column", "FLAGGED")
     )
     # [end_block_2]
     print(tf.df)
@@ -44,10 +51,9 @@ def comparison_qc_3() -> None:
 
     # [start_block_4]
     error_codes = [991, 992, 993, 994, 995]
-    tf.init_flag_column("qc", "flag_sensor_codes")
     tf = tf.qc_check(
         "comparison", "sensor_codes", compare_to=error_codes, operator="is_in",
-        flag_params=("flag_sensor_codes", "FLAGGED")
+        flag_params=("flag_column", "FLAGGED")
     )
     # [end_block_4]
     print(tf.df)
@@ -59,7 +65,6 @@ def range_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_5]
-    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
         "range",
         "temperature",
@@ -67,7 +72,7 @@ def range_qc_1() -> None:
         max_value=50,
         closed="none",  # Range is not inclusive of min and max value
         within=False,  # Flag values outside of this range
-        flag_params=("flag_temperature", "FLAGGED"),
+        flag_params=("flag_column", "FLAGGED"),
     )
     # [end_block_5]
     print(tf.df)
@@ -79,9 +84,8 @@ def spike_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_7]
-    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "spike", "temperature", threshold=10.0, flag_params=("flag_temperature", "FLAGGED")
+        "spike", "temperature", threshold=10.0, flag_params=("flag_column", "FLAGGED")
     )
     # [end_block_7]
     print(tf.df)
@@ -94,13 +98,12 @@ def time_range_qc_1() -> None:
         tf = create_simple_time_series()
 
     # [start_block_9]
-    tf.init_flag_column("qc", "flag_precipitation")
     tf = tf.qc_check(
         "time_range",
         "precipitation",
         min_value=time(1, 0),
         max_value=time(3, 0),
-        flag_params=("flag_precipitation", "FLAGGED")
+        flag_params=("flag_column", "FLAGGED")
     )
     # [end_block_9]
     print(tf.df)
@@ -112,13 +115,12 @@ def time_range_qc_2() -> None:
         tf = create_simple_time_series()
 
     # [start_block_10]
-    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
         "time_range",
         "temperature",
         min_value=datetime(2023, 1, 1, 3, 30),
         max_value=datetime(2023, 1, 1, 9, 30),
-        flag_params=("flag_temperature", "FLAGGED"),
+        flag_params=("flag_column", "FLAGGED"),
     )
     # [end_block_10]
     print(tf.df)
@@ -129,7 +131,7 @@ def create_flat_line_time_series() -> ts.TimeFrame:
     temperature = [18.0, 20.0, 20.0, 20.0, 20.0, 22.0, 21.0, 0.0, 0.0, 0.0]
     df = pl.DataFrame({"timestamp": dates, "temperature": temperature})
     tf = ts.TimeFrame(df=df, time_name="timestamp")
-    tf.register_flag_system("qc", {"FLAGGED": 1})
+    tf = setup_flags(tf)
     return tf
 
 
@@ -139,7 +141,7 @@ def create_near_flat_line_time_series() -> ts.TimeFrame:
     temperature = [18.0, 20.0, 20.005, 20.001, 19.991, 22.0, 20.99, 21.003, 21.009, 20.997]
     df = pl.DataFrame({"timestamp": dates, "temperature": temperature})
     tf = ts.TimeFrame(df=df, time_name="timestamp")
-    tf.register_flag_system("qc", {"FLAGGED": 1})
+    tf = setup_flags(tf)
     return tf
 
 
@@ -149,9 +151,8 @@ def flat_line_qc_1() -> None:
         tf = create_flat_line_time_series()
 
     # [start_block_11]
-    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "flat_line", "temperature", min_count=3, flag_params=("flag_temperature", "FLAGGED")
+        "flat_line", "temperature", min_count=3, flag_params=("flag_column", "FLAGGED")
     )
     # [end_block_11]
     print(tf.df)
@@ -164,9 +165,8 @@ def flat_line_qc_2() -> None:
         tf = create_flat_line_time_series()
 
     # [start_block_12]
-    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "flat_line", "temperature", min_count=3, ignore_value=0.0, flag_params=("flag_temperature", "FLAGGED")
+        "flat_line", "temperature", min_count=3, ignore_value=0.0, flag_params=("flag_column", "FLAGGED")
     )
     # [end_block_12]
     print(tf.df)
@@ -179,9 +179,8 @@ def flat_line_qc_3() -> None:
         tf = create_near_flat_line_time_series()
 
     # [start_block_13]
-    tf.init_flag_column("qc", "flag_temperature")
     tf = tf.qc_check(
-        "flat_line", "temperature", min_count=3, tolerance=0.1, flag_params=("flag_temperature", "FLAGGED")
+        "flat_line", "temperature", min_count=3, tolerance=0.1, flag_params=("flag_column", "FLAGGED")
     )
     # [end_block_13]
     print(tf.df)

--- a/src/time_stream/infill.py
+++ b/src/time_stream/infill.py
@@ -6,6 +6,7 @@ Polars and SciPy. Infill methods are implemented as subclasses of ``InfillMethod
 and instantiated by name, class, or instance.
 
 The infill pipeline handles:
+
 - Padding the time series to ensure consistent timestamps
 - Identifying gaps and their sizes
 - Applying constraints such as maximum gap size and observation intervals

--- a/src/time_stream/qc.py
+++ b/src/time_stream/qc.py
@@ -5,6 +5,7 @@ This module provides a framework for applying quality control checks to TimeFram
 implemented as subclasses of ``QCCheck`` and can be registered and instantiated by name, class, or instance.
 
 It supports various QC checks including:
+
 - ComparisonCheck: Compare values against thresholds or sets.
 - RangeCheck: Verify values fall within or outside a given range.
 - TimeRangeCheck: Apply range checks directly to the time column.


### PR DESCRIPTION
# Overview
- Add flagging user guide (docs/source/user_guide/flagging.rst) covering all three flag system types (bitwise, categorical single, categorical list), flag columns, adding/removing flags, filtering, and decode/encode
- Restructure infilling and quality control user guides so each method follows a consistent format with "What it does", "When to use", "Additional args", and "Example usage" sections (matching the existing aggregation methods style)
- Update the flagging system section in the concepts page to describe all three flag system types and remove the outdated requirement that flag columns are linked to a specific data column
- Add API reference pages for aggregation functions, infill methods, QC checks, and new TimeFrame flagging methods (decode_flag_column, encode_flag_column, filter_by_flag)
- Clean up base.py docstrings