### PR TITLE
Release v1.1.1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,3 +39,69 @@ jobs:
     with:
       pages_artifact_name: pages-artifact
 
+  release-ready:
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump and changelog
+        run: |
+          BASE_VER=$(git show origin/main:pyproject.toml | grep '^version' | sed 's/.*"\(.*\)"/\1/')
+          NEW_VER=$(grep '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+
+          if [ "$BASE_VER" = "$NEW_VER" ]; then
+            echo "ERROR: merges to main require a version bump (current: $NEW_VER)"
+            exit 1
+          fi
+
+          echo "Version bumped: $BASE_VER -> $NEW_VER"
+
+          CHANGELOG="CHANGELOG/${NEW_VER}.md"
+
+          if [ ! -f "$CHANGELOG" ]; then
+            echo "ERROR: $CHANGELOG not found"
+            exit 1
+          fi
+
+          if grep -q "<!-- Add release notes here -->" "$CHANGELOG"; then
+            echo "ERROR: $CHANGELOG still contains the stub placeholder"
+            exit 1
+          fi
+
+          LINES=$(tail -n +2 "$CHANGELOG" | grep -vc '^$')
+          if [ "$LINES" -eq 0 ]; then
+            echo "ERROR: $CHANGELOG has no content beyond the heading"
+            exit 1
+          fi
+
+          echo "Changelog looks good"
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test-python]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Configure git identity
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(grep '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+          if git ls-remote --tags origin | grep -q "refs/tags/v$VERSION$"; then
+            echo "Tag v$VERSION already exists — skipping release"
+            exit 0
+          fi
+          make release

--- a/CHANGELOG/1.1.1.md
+++ b/CHANGELOG/1.1.1.md
@@ -1,0 +1,3 @@
+# 1.1.1
+
+<!-- Add release notes here -->

--- a/CHANGELOG/1.1.1.md
+++ b/CHANGELOG/1.1.1.md
@@ -1,3 +1,10 @@
 # 1.1.1
 
-<!-- Add release notes here -->
+This release fixes incorrect type hints on the `missing_criteria` parameter.
+
+## Bug fixes
+
+- **`missing_criteria` type hints** - the first element of the `missing_criteria` tuple in `TimeFrame.aggregate()`,
+  `TimeFrame.rolling_aggregate()`, and the internal pipeline classes (`AggregationPipeline`,
+  `StandardAggregationPipeline`, `RollingAggregationPipeline`) was incorrectly typed as `str`. It is now correctly typed
+  as `MissingCriteria`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,7 +31,7 @@ authors:
 abstract: "Time Series Toolkit for Rapid Environmental Analysis and Monitoring: A Python library for handling and analysing timeseries data with a focus on maintaining the integrity of the temporal properties of the data."
 repository-code: "https://github.com/NERC-CEH/time-stream"
 license: MIT
-version: 1.1.0
+version: 1.1.1
 contact:
   - given-names: "Richard"
     family-names: "Smith"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "time-stream"
-version = "1.1.0"
+version = "1.1.1"
 description = "Time-Stream: Time Series Toolkit for Rapid Environmental Analysis and Monitoring"
 readme = "README.md"
 authors = [

--- a/src/time_stream/aggregation.py
+++ b/src/time_stream/aggregation.py
@@ -76,7 +76,7 @@ class AggregationPipeline(ABC):
         ctx: AggregationCtx,
         aggregation_period: Period,
         columns: str | list[str],
-        missing_criteria: tuple[str, float | int] | None = None,
+        missing_criteria: tuple[MissingCriteria, float | int] | None = None,
     ):
         self.agg_func = agg_func
         self.ctx = ctx
@@ -307,7 +307,7 @@ class StandardAggregationPipeline(AggregationPipeline):
         ctx: AggregationCtx,
         aggregation_period: Period,
         columns: str | list[str],
-        missing_criteria: tuple[str, float | int] | None = None,
+        missing_criteria: tuple[MissingCriteria, float | int] | None = None,
         aggregation_time_anchor: TimeAnchor | None = None,
         time_window: TimeWindow | None = None,
     ):
@@ -426,7 +426,7 @@ class RollingAggregationPipeline(AggregationPipeline):
         ctx: AggregationCtx,
         aggregation_period: Period,
         columns: str | list[str],
-        missing_criteria: tuple[str, float | int] | None = None,
+        missing_criteria: tuple[MissingCriteria, float | int] | None = None,
         alignment: RollingAlignment = "trailing",
     ):
         super().__init__(agg_func, ctx, aggregation_period, columns, missing_criteria)

--- a/src/time_stream/base.py
+++ b/src/time_stream/base.py
@@ -65,7 +65,14 @@ from time_stream.metadata import ColumnMetadataDict
 from time_stream.period import Period
 from time_stream.qc import QCCheck
 from time_stream.time_manager import TimeManager
-from time_stream.types import ClosedInterval, DuplicateOption, RollingAlignment, TimeAnchor, ValidationErrorOptions
+from time_stream.types import (
+    ClosedInterval,
+    DuplicateOption,
+    MissingCriteria,
+    RollingAlignment,
+    TimeAnchor,
+    ValidationErrorOptions,
+)
 from time_stream.utils import TimeWindow, check_columns_in_dataframe, configure_period_object, pad_time
 
 
@@ -700,7 +707,7 @@ class TimeFrame:
         aggregation_period: Period | str,
         aggregation_function: str | Type[AggregationFunction] | AggregationFunction,
         columns: str | list[str] | None = None,
-        missing_criteria: tuple[str, float | int] | None = None,
+        missing_criteria: tuple[MissingCriteria, float | int] | None = None,
         aggregation_time_anchor: TimeAnchor | None = None,
         time_window: tuple[time, time] | tuple[time, time, ClosedInterval] | TimeWindow | None = None,
         **kwargs,
@@ -776,7 +783,7 @@ class TimeFrame:
         window_size: Period | str,
         aggregation_function: str | Type[AggregationFunction] | AggregationFunction,
         columns: str | list[str] | None = None,
-        missing_criteria: tuple[str, float | int] | None = None,
+        missing_criteria: tuple[MissingCriteria, float | int] | None = None,
         alignment: RollingAlignment = "trailing",
         **kwargs,
     ) -> TimeFrame:

--- a/tests/time_stream/test_aggregation.py
+++ b/tests/time_stream/test_aggregation.py
@@ -33,6 +33,7 @@ from time_stream.exceptions import (
     UnknownRegistryKeyError,
 )
 from time_stream.period import Period
+from time_stream.types import MissingCriteria
 from time_stream.utils import TimeWindow
 
 
@@ -168,7 +169,7 @@ class TestStandardAggregationPipeline:
             ("na", 0),
         ],
     )
-    def test_missing_data_expr_validation_pass(self, criteria: str, threshold: int) -> None:
+    def test_missing_data_expr_validation_pass(self, criteria: MissingCriteria, threshold: int) -> None:
         """Test missing data expression validation that should pass."""
         ctx = self.setup_agg_context()
         columns = ["values"]
@@ -198,7 +199,7 @@ class TestStandardAggregationPipeline:
             ("available", 10.5),
         ],
     )
-    def test_missing_data_expr_validation_fail(self, criteria: str, threshold: int) -> None:
+    def test_missing_data_expr_validation_fail(self, criteria: MissingCriteria, threshold: int) -> None:
         """Test missing data expression validations that should fail."""
         ctx = self.setup_agg_context()
         columns = ["values"]
@@ -1657,7 +1658,7 @@ class TestMissingCriteriaAggregations:
             "available 23",
         ],
     )
-    def test_missing_criteria(self, valid: dict, criteria: tuple[str, float | int] | None) -> None:
+    def test_missing_criteria(self, valid: dict, criteria: tuple[MissingCriteria, float | int] | None) -> None:
         """Test aggregation of time series that has missing data with a various missing criteria"""
         expected_df = generate_expected_df(
             self.timestamps,

--- a/uv.lock
+++ b/uv.lock
@@ -2136,7 +2136,7 @@ wheels = [
 
 [[package]]
 name = "time-stream"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
# 1.1.1

This release fixes incorrect type hints on the `missing_criteria` parameter.

## Bug fixes

- **`missing_criteria` type hints** - the first element of the `missing_criteria` tuple in `TimeFrame.aggregate()`,
  `TimeFrame.rolling_aggregate()`, and the internal pipeline classes (`AggregationPipeline`,
  `StandardAggregationPipeline`, `RollingAggregationPipeline`) was incorrectly typed as `str`. It is now correctly typed
  as `MissingCriteria`.
