### PR TITLE
Update code to relfect warnings from updated packages

### DIFF
--- a/src/time_stream/flags/categorical_flag_system.py
+++ b/src/time_stream/flags/categorical_flag_system.py
@@ -184,7 +184,7 @@ class CategoricalListFlag(CategoricalSingleFlag, metaclass=CategoricalListMeta):
             CategoricalFlagUnknownError: If the series contains values not in this flag system.
         """
         valid_values = set(cls.to_dict().values())
-        unknown = set(series.explode().drop_nulls().unique().to_list()) - valid_values
+        unknown = set(series.explode(empty_as_null=True).drop_nulls().unique().to_list()) - valid_values
 
         if unknown:
             raise CategoricalFlagUnknownError(

--- a/src/time_stream/flags/flag_manager.py
+++ b/src/time_stream/flags/flag_manager.py
@@ -177,7 +177,7 @@ class BitwiseFlagColumn(FlagColumn):
             BitwiseFlagUnknownError: If any flag name in the column is not in the flag system.
         """
         flag_map = self.flag_system.to_dict()
-        present = set(df[self.name].explode().drop_nulls().unique().to_list())
+        present = set(df[self.name].explode(empty_as_null=True).drop_nulls().unique().to_list())
         unknown = present - flag_map.keys()
         if unknown:
             raise BitwiseFlagUnknownError(f"Unknown flag names in column '{self.name}': {sorted(unknown)}.")
@@ -504,7 +504,7 @@ class CategoricalListFlagColumn(FlagColumn):
         vtype = self.flag_system.value_type()
         return_dtype = pl.Int32 if vtype is int else pl.Utf8
 
-        present = set(df[self.name].explode().drop_nulls().unique().to_list())
+        present = set(df[self.name].explode(empty_as_null=True).drop_nulls().unique().to_list())
         unknown = present - flag_map.keys()
         if unknown:
             raise CategoricalFlagUnknownError(f"Unknown flag names in column '{self.name}': {sorted(unknown)}.")

--- a/src/time_stream/infill.py
+++ b/src/time_stream/infill.py
@@ -834,7 +834,7 @@ class AltDataDynamic(InfillMethod):
                 f"window size is below min threshold ({self.min_threshold}).",
             )
         valid_ids = window_sizes.filter(pl.col("__COUNT__") >= self.min_threshold)[gap_id_column_name]
-        return windowed_df.filter(pl.col(gap_id_column_name).is_in(valid_ids))
+        return windowed_df.filter(pl.col(gap_id_column_name).is_in(valid_ids.implode()))
 
     def _build_correction_factors(
         self,

--- a/tests/time_stream/examples/test_examples.py
+++ b/tests/time_stream/examples/test_examples.py
@@ -32,7 +32,7 @@ def all_example_funcs() -> Iterator[tuple[str, Callable]]:
 
 
 class TestExampleFunctions:
-    @pytest.mark.parametrize("name,func", all_example_funcs())
+    @pytest.mark.parametrize("name,func", list(all_example_funcs()))
     def test_examples(self, name: str, func: Callable) -> None:
         """Test that each example function can be called without errors."""
         func()


### PR DESCRIPTION
Fixing these warnings:


=============================== warnings summary ===============================                                                                                                                                         
  .venv/lib/python3.12/site-packages/_pytest/python.py:124                                                                                                                                                                 
    /home/runner/work/time-stream/time-stream/.venv/lib/python3.12/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.                          
    Test: tests/time_stream/examples/test_examples.py::TestExampleFunctions::test_examples, argvalues type: generator                                                                                                      
    Please convert to a list or tuple.                                                                                                                                                                                     
    See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators                                                                                                                                          
      metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)                                                                                                                                              
                                                                                                                                                                                                                           
  tests/time_stream/examples/test_examples.py: 1 warning                                                                                                                                                                   
  tests/time_stream/flags/test_bitwise_flag.py: 12 warnings                                                                                                                                                                
    /home/runner/work/time-stream/time-stream/src/time_stream/flags/flag_manager.py:180: DeprecationWarning: In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. To keep the current behavior, 
  explicitly set `empty_as_null=True`.                                                                                                                                                                                     
      present = set(df[self.name].explode().drop_nulls().unique().to_list())                                                                                                                                               
                                                                                                                                                                                                                           
  tests/time_stream/examples/test_examples.py::TestExampleFunctions::test_examples[examples_infilling.alt_data_dynamic_infill_with_thresholds-alt_data_dynamic_infill_with_thresholds]                                     
  tests/time_stream/test_infill.py::TestAltDataDynamic::test_infill_with_min_threshold                                                                                                                                     
  tests/time_stream/test_infill.py::TestAltDataDynamic::test_infill_with_max_threshold_and_one_sided_window                                                                                                                
    /home/runner/work/time-stream/time-stream/src/time_stream/infill.py:837: DeprecationWarning: `is_in` with a collection of the same datatype is ambiguous and deprecated.                                               
    Please use `implode` to return to previous behavior.                                                                                                                                                                   
                                                                                                                                                                                                                           
    See https://github.com/pola-rs/polars/issues/22149 for more information.                                                                                                                                               
      return windowed_df.filter(pl.col(gap_id_column_name).is_in(valid_ids))                                                                                                                                               
                                                                                                                                                                                                                           
  tests/time_stream/flags/test_categorical_flag.py::TestCategoricalListFlagValidateColumn::test_list_valid_values_pass                                                                                                     
  tests/time_stream/flags/test_categorical_flag.py::TestCategoricalListFlagValidateColumn::test_list_invalid_value_raises                                                                                                  
  tests/time_stream/flags/test_categorical_flag.py::TestRegisterFlagColumnBySystemType::test_list_flag_system_creates_list_column                                                                                          
    /home/runner/work/time-stream/time-stream/src/time_stream/flags/categorical_flag_system.py:187: DeprecationWarning: In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. To keep the        
  current behavior, explicitly set `empty_as_null=True`.                                                                                                                                                                   
      unknown = set(series.explode().drop_nulls().unique().to_list()) - valid_values                                                                                                                                       
                                                                                                                                                                                                                           
  tests/time_stream/flags/test_categorical_flag.py::TestDecodeFlagColumn::test_int_list_add_remove_on_decoded                                                                                                              
  tests/time_stream/flags/test_categorical_flag.py::TestDecodeFlagColumn::test_int_list_add_remove_on_decoded                                                                                                              
  tests/time_stream/flags/test_categorical_flag.py::TestEncodeFlagColumn::test_int_list_round_trip                                                                                                                         
  tests/time_stream/flags/test_categorical_flag.py::TestEncodeFlagColumn::test_int_list_unknown_name_raises                                                                                                                
    /home/runner/work/time-stream/time-stream/src/time_stream/flags/flag_manager.py:507: DeprecationWarning: In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. To keep the current behavior, 
  explicitly set `empty_as_null=True`.                                                                                                                                                                                     
      present = set(df[self.name].explode().drop_nulls().unique().to_list())